### PR TITLE
ignore md files for action flow

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/**.md'
+      - '**.md'
 jobs:
   test:
     name: Test


### PR DESCRIPTION
prevent actions from trigeering if we're just updating or adding md files such as standup meetings