### PR TITLE
jv - await update before reloading the window

### DIFF
--- a/client/src/components/list/EditAnimeModalForm.tsx
+++ b/client/src/components/list/EditAnimeModalForm.tsx
@@ -18,13 +18,13 @@ const EditAnimeModalForm: React.FC<EditAnimeModalFormProps> = ({ entryData }) =>
     initialValues: {
       score: entryData.rated ? entryData.rating : ''
     },
-    onSubmit: values => {
+    onSubmit: async values => {
       const updatedEntry: UserListEntryInput = {
         mediaID: entryData.mediaID,
         rated: (values.score !== ''),
         rating: (values.score !== '') ? Number(values.score) : 0
       };
-      updateUserListEntry({
+      await updateUserListEntry({
         variables: {
           input: updatedEntry
         }


### PR DESCRIPTION
Sometimes the window refreshes before the update user list mutation gets the chance to execute. This waits for the query to execute before reloading the window.