### PR TITLE
cb - Display images

### DIFF
--- a/client/src/components/list/UserList.tsx
+++ b/client/src/components/list/UserList.tsx
@@ -21,7 +21,7 @@ const UserList: React.FC<UserListProps> = ({ list }) => {
 
     return () => apolloClient.stop();
   }, [list]);
-  
+
   async function fetchAnimeInfo(apolloClient: ApolloClient<NormalizedCacheObject>) {
     const query = gql`
       query FetchAnimeInfo($ids: [Int]!) {
@@ -68,6 +68,7 @@ const UserList: React.FC<UserListProps> = ({ list }) => {
         <TableCaption>This is my animelist</TableCaption>
         <Thead>
           <Tr>
+            <Th></Th> {/* empty column for Cover Image */}
             <Th>Anime title</Th>
             <Th>Score</Th>
             <Th></Th> {/* empty column for Edit button */}
@@ -78,7 +79,7 @@ const UserList: React.FC<UserListProps> = ({ list }) => {
             // check if media is defined in case media ID wasn't in anilist database
             const media = medias.get(anime.mediaID);
 
-            return <UserListRow 
+            return <UserListRow
               key={anime.mediaID}
               entryData={{
                 ...anime,

--- a/client/src/components/list/UserList.tsx
+++ b/client/src/components/list/UserList.tsx
@@ -68,7 +68,7 @@ const UserList: React.FC<UserListProps> = ({ list }) => {
         <TableCaption>This is my animelist</TableCaption>
         <Thead>
           <Tr>
-            <Th></Th> {/* empty column for Cover Image */}
+            <Th>Image</Th>
             <Th>Anime title</Th>
             <Th>Score</Th>
             <Th></Th> {/* empty column for Edit button */}

--- a/client/src/components/list/UserListRow.tsx
+++ b/client/src/components/list/UserListRow.tsx
@@ -4,7 +4,7 @@ import { BsDash } from "react-icons/bs";
 import { Td, Tr } from "@chakra-ui/table";
 import { UserListEntry } from "../../generated/graphql";
 import { Button } from "@chakra-ui/react";
-import { useDisclosure } from "@chakra-ui/react"
+import { useDisclosure, Image } from "@chakra-ui/react"
 import EditAnimeModal from "./EditAnimeModal";
 
 interface UserListEntryExtended extends UserListEntry {
@@ -26,6 +26,7 @@ const UserListRow: React.FC<UserListRowProps> = ({ entryData }) => {
 
   return (
     <Tr>
+      <Image src={entryData.coverImage} />
       <Td>{entryData.title}</Td>
       <Td>{entryData.rated ? entryData.rating : <Icon as={BsDash} />}</Td>
       <Td><Button onClick={onOpen}> Edit </Button></Td>

--- a/client/src/components/list/UserListRow.tsx
+++ b/client/src/components/list/UserListRow.tsx
@@ -26,7 +26,7 @@ const UserListRow: React.FC<UserListRowProps> = ({ entryData }) => {
 
   return (
     <Tr>
-      <Image src={entryData.coverImage} />
+      <Image src={entryData.coverImage}/>
       <Td>{entryData.title}</Td>
       <Td>{entryData.rated ? entryData.rating : <Icon as={BsDash} />}</Td>
       <Td><Button onClick={onOpen}> Edit </Button></Td>
@@ -36,4 +36,4 @@ const UserListRow: React.FC<UserListRowProps> = ({ entryData }) => {
 }
 
 export default UserListRow;
-export type {UserListEntryExtended};
+export type { UserListEntryExtended };

--- a/client/src/components/list/UserListRow.tsx
+++ b/client/src/components/list/UserListRow.tsx
@@ -26,7 +26,7 @@ const UserListRow: React.FC<UserListRowProps> = ({ entryData }) => {
 
   return (
     <Tr>
-      <Td><Image src={entryData.coverImage} height="100"/></Td>
+      <Td><Image src={entryData.coverImage} width="67px" height="100px" objectFit="cover"/></Td>
       <Td>{entryData.title}</Td>
       <Td>{entryData.rated ? entryData.rating : <Icon as={BsDash} />}</Td>
       <Td><Button onClick={onOpen}> Edit </Button></Td>

--- a/client/src/components/list/UserListRow.tsx
+++ b/client/src/components/list/UserListRow.tsx
@@ -26,7 +26,7 @@ const UserListRow: React.FC<UserListRowProps> = ({ entryData }) => {
 
   return (
     <Tr>
-      <Image src={entryData.coverImage}/>
+      <Td><Image src={entryData.coverImage}/></Td>
       <Td>{entryData.title}</Td>
       <Td>{entryData.rated ? entryData.rating : <Icon as={BsDash} />}</Td>
       <Td><Button onClick={onOpen}> Edit </Button></Td>

--- a/client/src/components/list/UserListRow.tsx
+++ b/client/src/components/list/UserListRow.tsx
@@ -26,7 +26,7 @@ const UserListRow: React.FC<UserListRowProps> = ({ entryData }) => {
 
   return (
     <Tr>
-      <Td><Image src={entryData.coverImage} height="100" width="auto" /></Td>
+      <Td><Image src={entryData.coverImage} height="100"/></Td>
       <Td>{entryData.title}</Td>
       <Td>{entryData.rated ? entryData.rating : <Icon as={BsDash} />}</Td>
       <Td><Button onClick={onOpen}> Edit </Button></Td>

--- a/client/src/components/list/UserListRow.tsx
+++ b/client/src/components/list/UserListRow.tsx
@@ -26,7 +26,7 @@ const UserListRow: React.FC<UserListRowProps> = ({ entryData }) => {
 
   return (
     <Tr>
-      <Td><Image src={entryData.coverImage}/></Td>
+      <Td><Image src={entryData.coverImage} height="100" width="auto" /></Td>
       <Td>{entryData.title}</Td>
       <Td>{entryData.rated ? entryData.rating : <Icon as={BsDash} />}</Td>
       <Td><Button onClick={onOpen}> Edit </Button></Td>

--- a/client/src/components/result/SearchResult.tsx
+++ b/client/src/components/result/SearchResult.tsx
@@ -23,7 +23,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ anime }) => {
   }
   return (
     <HStack>
-      <Image src={anime.coverImage.medium} height="150" width="auto "/>
+      <Image src={anime.coverImage.medium} height="150"/>
       <Stack
         height="100%"
         alignItems="flex-start"

--- a/client/src/components/result/SearchResult.tsx
+++ b/client/src/components/result/SearchResult.tsx
@@ -23,7 +23,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ anime }) => {
   }
   return (
     <HStack>
-      <Image src={anime.coverImage.medium} />
+      <Image src={anime.coverImage.medium} height="150" width="auto "/>
       <Stack
         height="100%"
         alignItems="flex-start"

--- a/client/src/components/result/SearchResult.tsx
+++ b/client/src/components/result/SearchResult.tsx
@@ -23,7 +23,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ anime }) => {
   }
   return (
     <HStack>
-      <Image src={anime.coverImage.medium} height="150"/>
+      <Image src={anime.coverImage.medium} width="67px" height="100px" objectFit="cover"/>
       <Stack
         height="100%"
         alignItems="flex-start"


### PR DESCRIPTION
- In this PR, cover images are successfully displayed for each anime on the user's list with a standardized height (aspect ratio not changed for individual images though).
- I added an image entry for the columns title field.
- Because Anilist already includes a placeholder image for each anime without an official "cover image," the code for displaying the image will remain the same because it comes from the same field from the anilist query.
- I also quickly standardized the height for the search results. Apparently, not all the image heights were the same before, we just happened to look up anime with cover images of the same or similar height lol.
- Acceptance criteria are all passing.

![userListCoverImages](https://user-images.githubusercontent.com/55938466/140445735-22093d3b-69e7-407c-b3e3-90faf7dbf13a.PNG)

Closes #76 