### PR TITLE
Create user list API layer

### DIFF
--- a/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
@@ -7,6 +7,7 @@ import com.github.animelist.animelist.model.input.UserListItemInput;
 import com.github.animelist.animelist.model.user.UserListEntry;
 import com.github.animelist.animelist.model.userlist.UserList;
 import com.github.animelist.animelist.model.userlist.UserListItem;
+import com.github.animelist.animelist.model.userlist.UserListRating;
 import com.github.animelist.animelist.model.userlist.WatchStatus;
 import com.github.animelist.animelist.service.UserListService;
 import com.github.animelist.animelist.util.AuthUtil;
@@ -52,10 +53,12 @@ public class UserListController {
     @PreAuthorize("isAuthenticated()")
     public UserListItem addUserListItem(@Argument("input") final UserListItemInput input) {
         final var userDetails = AuthUtil.getUserDetails();
+
+        // TODO: Put scoring algorithm to get correct UserListRating
         final var userListItem = UserListItem.builder()
                 .mediaID(input.mediaID())
-                .watchStatus(WatchStatus.valueOf(input.watchStatus().toUpperCase()))
-                .rating(input.rating())
+                .watchStatus(input.watchStatus())
+                .rating(UserListRating.builder().subRatings(input.subRatings()).build())
                 .build();
 
         if (!userListService.addItem(input.listId(), userDetails.getId(), userListItem)) {
@@ -69,10 +72,16 @@ public class UserListController {
     @PreAuthorize("isAuthenticated()")
     public UserListItem updateUserListItem(@Argument("input") final UserListItemInput input) {
         final var userDetails = AuthUtil.getUserDetails();
+
+        // TODO: Put scoring algorithm to get correct UserListRating
         final var userListItem = UserListItem.builder()
                 .mediaID(input.mediaID())
-                .watchStatus(WatchStatus.valueOf(input.watchStatus().toUpperCase()))
-                .rating(input.rating())
+                .watchStatus(input.watchStatus())
+                .rating(UserListRating.builder()
+                        .rating(0)
+                        .displayRating("This a test")
+                        .subRatings(input.subRatings())
+                        .build())
                 .build();
 
         if (!userListService.updateItem(input.listId(), userDetails.getId(), userListItem)) {

--- a/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
@@ -60,7 +60,7 @@ public class UserListController {
                 .watchStatus(input.watchStatus())
                 .rating(UserListRating.builder()
                         .rating(0)
-                        .displayRating("This a test")
+                        .displayRating("STUB")
                         .subRatings(input.subRatings())
                         .build())
                 .build();
@@ -83,7 +83,7 @@ public class UserListController {
                 .watchStatus(input.watchStatus())
                 .rating(UserListRating.builder()
                         .rating(0)
-                        .displayRating("This a test")
+                        .displayRating("STUB")
                         .subRatings(input.subRatings())
                         .build())
                 .build();

--- a/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
@@ -58,7 +58,11 @@ public class UserListController {
         final var userListItem = UserListItem.builder()
                 .mediaID(input.mediaID())
                 .watchStatus(input.watchStatus())
-                .rating(UserListRating.builder().subRatings(input.subRatings()).build())
+                .rating(UserListRating.builder()
+                        .rating(0)
+                        .displayRating("This a test")
+                        .subRatings(input.subRatings())
+                        .build())
                 .build();
 
         if (!userListService.addItem(input.listId(), userDetails.getId(), userListItem)) {

--- a/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/UserListController.java
@@ -4,6 +4,7 @@ import com.github.animelist.animelist.model.JwtUserDetails;
 import com.github.animelist.animelist.model.input.CreateUserListInput;
 import com.github.animelist.animelist.model.input.UserListEntryInput;
 import com.github.animelist.animelist.model.input.UserListItemInput;
+import com.github.animelist.animelist.model.ratingsystem.ContinuousRatingSystem;
 import com.github.animelist.animelist.model.user.UserListEntry;
 import com.github.animelist.animelist.model.userlist.UserList;
 import com.github.animelist.animelist.model.userlist.UserListItem;
@@ -44,6 +45,7 @@ public class UserListController {
         final var userList = UserList.builder()
                 .name(input.name())
                 .ownerId(new ObjectId(userDetails.getId()))
+                .ratingSystem(ContinuousRatingSystem.TEN_POINT)
                 .build();
 
         return userListService.createUserList(userList);

--- a/server/src/main/java/com/github/animelist/animelist/model/input/CreateUserListInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/CreateUserListInput.java
@@ -1,0 +1,4 @@
+package com.github.animelist.animelist.model.input;
+
+public record CreateUserListInput(String name) {
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/input/UserListItemInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/UserListItemInput.java
@@ -1,0 +1,6 @@
+package com.github.animelist.animelist.model.input;
+
+import com.github.animelist.animelist.model.userlist.UserListRating;
+
+public record UserListItemInput(String listId, Integer mediaID, String watchStatus, UserListRating rating) {
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/input/UserListItemInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/UserListItemInput.java
@@ -1,6 +1,9 @@
 package com.github.animelist.animelist.model.input;
 
-import com.github.animelist.animelist.model.userlist.UserListRating;
+import com.github.animelist.animelist.model.userlist.UserListSubRating;
+import com.github.animelist.animelist.model.userlist.WatchStatus;
 
-public record UserListItemInput(String listId, Integer mediaID, String watchStatus, UserListRating rating) {
+import java.util.List;
+
+public record UserListItemInput(String listId, Integer mediaID, WatchStatus watchStatus, List<UserListSubRating> subRatings) {
 }

--- a/server/src/main/java/com/github/animelist/animelist/model/ratingsystem/ContinuousRatingSystem.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/ratingsystem/ContinuousRatingSystem.java
@@ -3,8 +3,11 @@ package com.github.animelist.animelist.model.ratingsystem;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+
+import static java.util.Collections.singletonList;
 
 @Document("ratingSystems")
 public class ContinuousRatingSystem extends RatingSystem {
@@ -85,4 +88,18 @@ public class ContinuousRatingSystem extends RatingSystem {
             return new ContinuousRatingSystem(id, name, ownerId, size, subRatings, offset);
         }
     }
+
+    public static final ContinuousRatingSystem TEN_POINT = ContinuousRatingSystem.builder()
+            .id("DEFAULT")
+            .name("10-Point Continuous")
+            .size(10)
+            .subRatings(singletonList(
+                    SubRating.builder()
+                            .id(0)
+                            .name("Score")
+                            .weight(1f)
+                            .build()
+            ))
+            .offset(1)
+            .build();
 }

--- a/server/src/main/java/com/github/animelist/animelist/model/userlist/UserListRating.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/userlist/UserListRating.java
@@ -5,16 +5,13 @@ import java.util.Objects;
 
 public class UserListRating {
 
-    private Integer id;
-
     private String displayRating;
 
     private Integer rating;
 
     private List<UserListSubRating> subRatings;
 
-    public UserListRating(Integer id, String displayRating, Integer rating, List<UserListSubRating> subRatings) {
-        this.id = id;
+    public UserListRating(String displayRating, Integer rating, List<UserListSubRating> subRatings) {
         this.displayRating = displayRating;
         this.rating = rating;
         this.subRatings = subRatings;
@@ -25,20 +22,12 @@ public class UserListRating {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserListRating that = (UserListRating) o;
-        return Objects.equals(id, that.id) && Objects.equals(displayRating, that.displayRating) && Objects.equals(rating, that.rating) && Objects.equals(subRatings, that.subRatings);
+        return Objects.equals(displayRating, that.displayRating) && Objects.equals(rating, that.rating) && Objects.equals(subRatings, that.subRatings);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, displayRating, rating, subRatings);
-    }
-
-    public Integer getId() {
-        return id;
-    }
-
-    public void setId(Integer id) {
-        this.id = id;
+        return Objects.hash(displayRating, rating, subRatings);
     }
 
     public String getDisplayRating() {
@@ -70,15 +59,9 @@ public class UserListRating {
     }
 
     public static class Builder {
-        private Integer id;
         private String displayRating;
         private Integer rating;
         private List<UserListSubRating> subRatings;
-
-        public Builder id(Integer id) {
-            this.id = id;
-            return this;
-        }
 
         public Builder displayRating(String displayRating) {
             this.displayRating = displayRating;
@@ -96,7 +79,7 @@ public class UserListRating {
         }
 
         public UserListRating build() {
-            return new UserListRating(id, displayRating, rating, subRatings);
+            return new UserListRating(displayRating, rating, subRatings);
         }
     }
 }

--- a/server/src/main/resources/graphql/schema.graphqls
+++ b/server/src/main/resources/graphql/schema.graphqls
@@ -14,6 +14,31 @@ type UserListEntry {
   rating: Float!
 }
 
+type UserList {
+  id: ID!
+  ownerId: String!
+  name: String!
+  items: [UserListItem]
+}
+
+type UserListItem {
+  mediaID: Int!
+  watchStatus: String!
+  rating: UserListRating
+}
+
+type UserListRating {
+  displayRating: Int!
+  rating: Int!
+  subRatings: [UserListSubRating]
+}
+
+type UserListSubRating {
+  id: Int!
+  displayRating: String
+  rating: Int!
+}
+
 input UserListEntryInput {
   mediaID: Int!
   rated: Boolean!
@@ -46,10 +71,21 @@ input MALOauthInput {
   state: String!
 }
 
+input CreateUserListInput {
+  name: String!
+}
+
+input UserListItemInput {
+  mediaID: Int!
+  watchStatus: String!
+  rating: UserListRating!
+}
+
 type Query {
   me: User
   malLinkOauth: String!
   malLoginOauth: String!
+  userList(listId: String!): UserList
 }
 
 type Mutation {
@@ -60,4 +96,7 @@ type Mutation {
   malLink(input: MALOauthInput!): Boolean
   addListEntry(input: UserListEntryInput!): Boolean
   updateUserListEntry(input: UserListEntryInput!): UserListEntry
+  createUserList(input: CreateUserListInput!): UserList
+  addUserListItem(input: UserListItemInput!): UserListItem
+  updateUserListItem(input: UserListItemInput!): UserListItem
 }

--- a/server/src/main/resources/graphql/schema.graphqls
+++ b/server/src/main/resources/graphql/schema.graphqls
@@ -14,31 +14,6 @@ type UserListEntry {
   rating: Float!
 }
 
-type UserList {
-  id: ID!
-  ownerId: String!
-  name: String!
-  items: [UserListItem]
-}
-
-type UserListItem {
-  mediaID: Int!
-  watchStatus: String!
-  rating: UserListRating
-}
-
-type UserListRating {
-  displayRating: Int!
-  rating: Int!
-  subRatings: [UserListSubRating]
-}
-
-type UserListSubRating {
-  id: Int!
-  displayRating: String
-  rating: Int!
-}
-
 input UserListEntryInput {
   mediaID: Int!
   rated: Boolean!
@@ -71,17 +46,6 @@ input MALOauthInput {
   state: String!
 }
 
-input CreateUserListInput {
-  name: String!
-}
-
-input UserListItemInput {
-  listId: String!
-  mediaID: Int!
-  watchStatus: String!
-  rating: UserListRating!
-}
-
 type Query {
   me: User
   malLinkOauth: String!
@@ -98,6 +62,6 @@ type Mutation {
   addListEntry(input: UserListEntryInput!): Boolean
   updateUserListEntry(input: UserListEntryInput!): UserListEntry
   createUserList(input: CreateUserListInput!): UserList
-  addUserListItem(input: UserListItemInput!): UserListItem
-  updateUserListItem(input: UserListItemInput!): UserListItem
+  addUserListItem(input: AddUserListItemInput!): UserListItem
+  updateUserListItem(input: UpdateUserListItemInput!): UserListItem
 }

--- a/server/src/main/resources/graphql/schema.graphqls
+++ b/server/src/main/resources/graphql/schema.graphqls
@@ -76,6 +76,7 @@ input CreateUserListInput {
 }
 
 input UserListItemInput {
+  listId: String!
   mediaID: Int!
   watchStatus: String!
   rating: UserListRating!

--- a/server/src/main/resources/graphql/userListSchema.graphqls
+++ b/server/src/main/resources/graphql/userListSchema.graphqls
@@ -1,0 +1,55 @@
+type UserList {
+  id: ID!
+  ownerId: String!
+  name: String!
+  items: [UserListItem]
+}
+
+type UserListItem {
+  mediaID: Int!
+  watchStatus: String!
+  rating: UserListRating
+}
+
+type UserListRating {
+  displayRating: String!
+  rating: Int!
+  subRatings: [UserListSubRating!]!
+}
+
+enum WatchStatus {
+  PLAN_TO_WATCH
+  WATCHING
+  ON_HOLD
+  COMPLETED
+  DROPPED
+}
+
+type UserListSubRating {
+  id: Int!
+  displayRating: String
+  rating: Int!
+}
+
+input CreateUserListInput {
+  name: String!
+}
+
+input AddUserListItemInput {
+  listId: String!
+  mediaID: Int!
+  watchStatus: String!
+  subRatings: [UserListSubRatingInput]
+}
+
+input UpdateUserListItemInput {
+  listId: String!
+  mediaID: Int!
+  watchStatus: WatchStatus!
+  subRatings: [UserListSubRatingInput]!
+}
+
+input UserListSubRatingInput {
+  id: Int!
+  rating: Int!
+}

--- a/server/src/main/resources/graphql/userListSchema.graphqls
+++ b/server/src/main/resources/graphql/userListSchema.graphqls
@@ -38,7 +38,7 @@ input CreateUserListInput {
 input AddUserListItemInput {
   listId: String!
   mediaID: Int!
-  watchStatus: String!
+  watchStatus: WatchStatus!
   subRatings: [UserListSubRatingInput]
 }
 

--- a/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
+++ b/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
@@ -3,6 +3,7 @@ package com.github.animelist.animelist.controller;
 import com.github.animelist.animelist.model.JwtUserDetails;
 import com.github.animelist.animelist.model.input.CreateUserListInput;
 import com.github.animelist.animelist.model.input.UserListItemInput;
+import com.github.animelist.animelist.model.ratingsystem.ContinuousRatingSystem;
 import com.github.animelist.animelist.model.userlist.UserList;
 import com.github.animelist.animelist.model.userlist.UserListItem;
 import com.github.animelist.animelist.model.userlist.UserListRating;
@@ -43,6 +44,7 @@ public class UserListControllerTest {
         final UserList expectedUserList = UserList.builder()
                 .name("Test")
                 .ownerId(EXPECTED_OWNER_ID)
+                .ratingSystem(ContinuousRatingSystem.TEN_POINT)
                 .build();
 
         when(userListService.createUserList(expectedUserList)).thenReturn(expectedUserList);

--- a/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
+++ b/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
@@ -1,0 +1,131 @@
+package com.github.animelist.animelist.controller;
+
+import com.github.animelist.animelist.model.JwtUserDetails;
+import com.github.animelist.animelist.model.input.CreateUserListInput;
+import com.github.animelist.animelist.model.input.UserListItemInput;
+import com.github.animelist.animelist.model.userlist.UserList;
+import com.github.animelist.animelist.model.userlist.UserListItem;
+import com.github.animelist.animelist.model.userlist.UserListRating;
+import com.github.animelist.animelist.model.userlist.WatchStatus;
+import com.github.animelist.animelist.service.UserListService;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static com.github.animelist.animelist.util.TestUtil.TEST_USERNAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserListControllerTest {
+
+    @Mock
+    private UserListService userListService;
+
+    @InjectMocks
+    private UserListController userListController;
+
+    private final ObjectId EXPECTED_OWNER_ID = new ObjectId();
+
+    @Test
+    void createUserList_happy() {
+        mockAuthenticationPrincipal();
+        final CreateUserListInput input = new CreateUserListInput("Test");
+        final UserList expectedUserList = UserList.builder()
+                .name("Test")
+                .ownerId(EXPECTED_OWNER_ID)
+                .build();
+
+        when(userListService.createUserList(expectedUserList)).thenReturn(expectedUserList);
+
+        final UserList actualUserList = userListController.createUserList(input);
+
+        assertThat(actualUserList, is(expectedUserList));
+    }
+
+    @Test
+    void addUserListItem_happy() {
+        mockAuthenticationPrincipal();
+        final var listId = new ObjectId().toString();
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var expected = UserListItem.builder()
+                .mediaID(1234)
+                .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .build();
+
+        when(userListService.addItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(true);
+
+        final var actual = userListController.addUserListItem(input);
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    void addUserListItem_failAdd() {
+        mockAuthenticationPrincipal();
+        final var listId = new ObjectId().toString();
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var expected = UserListItem.builder()
+                .mediaID(1234)
+                .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .build();
+
+        when(userListService.addItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> userListController.addUserListItem(input));
+    }
+
+    @Test
+    void updateUserListItem_happy() {
+        mockAuthenticationPrincipal();
+        final var listId = new ObjectId().toString();
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var expected = UserListItem.builder()
+                .mediaID(1234)
+                .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .build();
+
+        when(userListService.updateItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(true);
+
+        final var actual = userListController.updateUserListItem(input);
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    void updateUserListItem_failUpdate() {
+        mockAuthenticationPrincipal();
+        final var listId = new ObjectId().toString();
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var expected = UserListItem.builder()
+                .mediaID(1234)
+                .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .build();
+
+        when(userListService.updateItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> userListController.updateUserListItem(input));
+    }
+
+    private void mockAuthenticationPrincipal() {
+        final JwtUserDetails mockJwtUserDetails = JwtUserDetails.builder()
+                .username(TEST_USERNAME)
+                .id(EXPECTED_OWNER_ID.toString())
+                .build();
+        final Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn(mockJwtUserDetails);
+        final SecurityContext secCtx = mock(SecurityContext.class);
+        when(secCtx.getAuthentication()).thenReturn(auth);
+
+        SecurityContextHolder.setContext(secCtx);
+    }
+}

--- a/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
+++ b/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
@@ -5,7 +5,6 @@ import com.github.animelist.animelist.model.input.CreateUserListInput;
 import com.github.animelist.animelist.model.input.UserListItemInput;
 import com.github.animelist.animelist.model.userlist.UserList;
 import com.github.animelist.animelist.model.userlist.UserListItem;
-import com.github.animelist.animelist.model.userlist.UserListRating;
 import com.github.animelist.animelist.model.userlist.WatchStatus;
 import com.github.animelist.animelist.service.UserListService;
 import org.bson.types.ObjectId;
@@ -56,7 +55,7 @@ public class UserListControllerTest {
     void addUserListItem_happy() {
         mockAuthenticationPrincipal();
         final var listId = new ObjectId().toString();
-        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH, null);
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)
@@ -73,7 +72,7 @@ public class UserListControllerTest {
     void addUserListItem_failAdd() {
         mockAuthenticationPrincipal();
         final var listId = new ObjectId().toString();
-        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH, null);
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)
@@ -88,7 +87,7 @@ public class UserListControllerTest {
     void updateUserListItem_happy() {
         mockAuthenticationPrincipal();
         final var listId = new ObjectId().toString();
-        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH, null);
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)
@@ -105,7 +104,7 @@ public class UserListControllerTest {
     void updateUserListItem_failUpdate() {
         mockAuthenticationPrincipal();
         final var listId = new ObjectId().toString();
-        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH.toString(), null);
+        final var input = new UserListItemInput(listId, 1234, WatchStatus.PLAN_TO_WATCH, null);
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)

--- a/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
+++ b/server/src/test/java/com/github/animelist/animelist/controller/UserListControllerTest.java
@@ -5,6 +5,7 @@ import com.github.animelist.animelist.model.input.CreateUserListInput;
 import com.github.animelist.animelist.model.input.UserListItemInput;
 import com.github.animelist.animelist.model.userlist.UserList;
 import com.github.animelist.animelist.model.userlist.UserListItem;
+import com.github.animelist.animelist.model.userlist.UserListRating;
 import com.github.animelist.animelist.model.userlist.WatchStatus;
 import com.github.animelist.animelist.service.UserListService;
 import org.bson.types.ObjectId;
@@ -59,6 +60,11 @@ public class UserListControllerTest {
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .rating(UserListRating.builder()
+                        .rating(0)
+                        .displayRating("STUB")
+                        .subRatings(input.subRatings())
+                        .build())
                 .build();
 
         when(userListService.addItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(true);
@@ -76,6 +82,11 @@ public class UserListControllerTest {
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .rating(UserListRating.builder()
+                        .rating(0)
+                        .displayRating("STUB")
+                        .subRatings(input.subRatings())
+                        .build())
                 .build();
 
         when(userListService.addItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(false);
@@ -91,6 +102,11 @@ public class UserListControllerTest {
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .rating(UserListRating.builder()
+                        .rating(0)
+                        .displayRating("STUB")
+                        .subRatings(input.subRatings())
+                        .build())
                 .build();
 
         when(userListService.updateItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(true);
@@ -108,11 +124,18 @@ public class UserListControllerTest {
         final var expected = UserListItem.builder()
                 .mediaID(1234)
                 .watchStatus(WatchStatus.PLAN_TO_WATCH)
+                .rating(UserListRating.builder()
+                        .rating(0)
+                        .displayRating("STUB")
+                        .subRatings(input.subRatings())
+                        .build())
                 .build();
 
-        when(userListService.updateItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(false);
+        when(userListService.updateItem(listId, EXPECTED_OWNER_ID.toString(), expected)).thenReturn(true);
 
-        assertThrows(RuntimeException.class, () -> userListController.updateUserListItem(input));
+        final var actual = userListController.updateUserListItem(input);
+
+        assertThrows(RuntimeException.class, () -> userListController.addUserListItem(input));
     }
 
     private void mockAuthenticationPrincipal() {


### PR DESCRIPTION
## Notes
- We should begin to write separate schema files for our types since putting it all in the root will become unmanageable
- Currently the Rating system validation and scoring is WIP so there is no functionality to set/use a Rating System for a user list currently thru the API
- We have hardcoded rating object and rating system currently
## Testing
- I tested manually thru graphiql editor
- Unit tests

graphql queries and mutations for reference
```
mutation {
  updateUserListItem(input: {
    listId: "618dca04981ad71e0ebb9d7c"
    mediaID: 1234
    watchStatus: WATCHING
    subRatings: [
        {
          id: 0
          rating: 10
        }
    ]
  }) {
    mediaID
    watchStatus
    rating {
      rating
      displayRating
      subRatings {
        id
        rating
      }
    }
  }
}
```
```
mutation {
  addUserListItem(input: {
    listId: "618dca04981ad71e0ebb9d7c"
    mediaID: 1234
    watchStatus: PLAN_TO_WATCH
  }) {
    mediaID
    watchStatus
  }
}
```
```
query {
  userList(listId: "618dca04981ad71e0ebb9d7c") {
    id
    name
  }
}
```
Closes #95 