### PR TITLE
Create rating system UI

### DIFF
--- a/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
+++ b/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
@@ -1,14 +1,16 @@
 import { 
     Input, 
     Radio, 
-    Stack, 
+    Stack,
+    VStack,
     Button,
     Heading,
     FormControl, 
     FormLabel,
     FormErrorMessage,
     FormHelperText,
-    RadioGroup
+    RadioGroup,
+    Center
 } from "@chakra-ui/react";
 
 import * as React from 'react';
@@ -62,28 +64,38 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
       }
     });
 
+    const [value, setValue] = React.useState("1");
+    const [value2, setValue2] = React.useState("1");
+
     return(
 
       <form onSubmit={formik.handleSubmit} id="createRatingSystem">
-
+        <Stack
+          spacing={{ base: 8, md: 8 }}
+        >
         <FormControl isInvalid={formik.errors.name && formik.touched.name} isRequired>
           <FormLabel>Name</FormLabel>
           <Input placeholder="MyRatingSystem" id="name"/>
         </FormControl>
     
         <FormControl isInvalid={formik.errors.type && formik.touched.type} isRequired>
-          <FormLabel>Type of rating system</FormLabel>
-          <RadioGroup>
-            <Stack>
-              <Radio id="CONTINUOUS">Continuous</Radio>
-              <Radio id="DISCRETE">Discrete</Radio>
-            </Stack>
-          </RadioGroup>
+          <Stack spacing="24px">
+            <FormLabel>Type of rating system</FormLabel>
+            <RadioGroup onChange={setValue} value={value}>
+              <Stack spacing="24px">
+                <Radio value="1" id="CONTINUOUS">Continuous</Radio>
+                <Radio value="2" id="DISCRETE">Discrete</Radio>
+              </Stack>
+            </RadioGroup>
+          </Stack>
         </FormControl>
+        
     
         <FormControl isRequired>
-          <Heading>Customize the range</Heading>
-          <Stack>
+          <Stack spacing="24px">
+            <Heading size="md">
+            Customize the range</Heading>
+          
             <FormLabel>Lower bound</FormLabel>
             <Input id="lowerBound"placeholder="0"/>
             <FormLabel>Upper bound</FormLabel>
@@ -92,26 +104,29 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
         </FormControl>
     
         <FormControl isRequired>
-          <FormLabel>Create your own subratings</FormLabel>
-          <RadioGroup>
+          <FormLabel>Create your own subratings?</FormLabel>
+          <RadioGroup onChange={setValue2} value={value2}>
             <Stack>
-              <Radio>Yes
+              <Radio value="1">Yes
                 <FormHelperText>(Must create at least 2)</FormHelperText>
               </Radio>
-              <Radio>No
+              <Radio value="2">No
                 <FormHelperText>(One will be created for you)</FormHelperText>
               </Radio>
             </Stack>
           </RadioGroup>
         </FormControl>
 
-        <Button
-          mt={6}
-          isLoading={formik.isSubmitting}
-          type="submit"
-        >
-        Create Rating System
-        </Button>
+        <Center>
+          <Button
+            mt={6}
+            isLoading={formik.isSubmitting}
+            type="submit"
+          >
+          Create Rating System
+          </Button>
+        </Center>
+        </Stack>
       </form>
     );
 };

--- a/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
+++ b/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
@@ -29,8 +29,8 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
 
     const validationSchema = Yup.object({
         name: Yup.string()
-          .min(3, 'Name must be at least 3 characters long')
-          .max(20, 'Name must be at most 20 characters long')
+          .min(1, 'Name must be at least 1 character long')
+          .max(50, 'Name must be at most 50 characters long')
           .required('Required'),
         type: Yup.string() // Either DISCRETE or CONTINUOUS
           .required('Required'),
@@ -91,15 +91,15 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
         </FormControl>
         
     
-        <FormControl isRequired>
+        <FormControl>
           <Stack spacing="24px">
             <Heading size="md">
             Customize the range</Heading>
           
             <FormLabel>Lower bound</FormLabel>
-            <Input id="lowerBound"placeholder="0"/>
+            <Input id="lowerBound" placeholder="0" isInvalid={formik.errors.lowerBound && formik.touched.lowerBound} isRequired/>
             <FormLabel>Upper bound</FormLabel>
-            <Input id="upperBound" placeholder="10"/>
+            <Input id="upperBound" placeholder="10" isInvalid={formik.errors.upperBound && formik.touched.upperBound} isRequired/>
           </Stack>
         </FormControl>
     

--- a/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
+++ b/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
@@ -30,26 +30,26 @@ import * as Yup from 'yup';
 // subrating: String!
 // subratings: [Subrating!]!
 
-function showLabels(){
-  // For Discrete Rating System
+function contElements(){
   var x = document.getElementById("labels") as HTMLElement;
-  x.style.display = "block";
+  x.style.display = "none";
+  var y = document.getElementById("range") as HTMLElement;
+  y.style.display = "block"
 }
 
-function hideLabels(){
-  // For Continuous Rating System
+function discElements(){
   var x = document.getElementById("labels") as HTMLElement;
-    x.style.display = "none";
+  x.style.display = "block";
+  var y = document.getElementById("range") as HTMLElement;
+  y.style.display = "none"
 }
 
 function showSubratings(){
-  // For Discrete Rating System
   var x = document.getElementById("subratings") as HTMLElement;
   x.style.display = "block";
 }
 
 function hideSubratings(){
-  // For Continuous Rating System
   var x = document.getElementById("subratings") as HTMLElement;
     x.style.display = "none";
 }
@@ -96,12 +96,18 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
     // Temp values for radios
     const [valueType, setValueType] = React.useState("1");
     const [valueSub, setValueSub] = React.useState("1");
+    const [lower, setLower] = React.useState(0);
+    const setL = (lower) => setLower(lower);
+    const [upper, setUpper] = React.useState(10);
+    const setU = (upper) => setUpper(upper);
+    let upper2 = +upper - +1;
+    let lower2 = +lower + +1;
 
     return(
 
       <form onSubmit={formik.handleSubmit} id="createRatingSystem">
         <Stack
-          spacing={{ base: 8, md: 8 }}
+          spacing={{ base: 8, md: 6 }}
         >
         <FormControl isRequired>
           <FormLabel>Name</FormLabel>
@@ -118,7 +124,7 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
               <Stack spacing="16px">
                 <Radio
                   size="lg" 
-                  onChange={hideLabels} 
+                  onChange={contElements} 
                   value="1" 
                   name="CONTINUOUS"
                 >
@@ -126,7 +132,7 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
                 </Radio>
                 <Radio 
                   size="lg" 
-                  onChange={showLabels} 
+                  onChange={discElements} 
                   value="2" 
                   name="DISCRETE"
                 >
@@ -137,14 +143,18 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
           </Stack>
         </FormControl>
     
+        <Stack id="range">
         <FormControl>
           <Stack spacing="24px">
-            <Heading size="md">
-            Customize the range</Heading>
+
+            <Heading size="md">Customize the scores</Heading>
           
-            <FormLabel>Lower bound</FormLabel>
+            <FormLabel>Lowest Score</FormLabel>
             <NumberInput
-              defaultValue="0"
+              value={lower}
+              max={upper2}
+              onChange={setL}
+              precision={0}
               id="lowerBound"
             >
               <NumberInputField />
@@ -154,9 +164,12 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
               </NumberInputStepper>
             </NumberInput>
 
-            <FormLabel>Upper bound</FormLabel>
+            <FormLabel>Highest Score</FormLabel>
             <NumberInput
-              defaultValue="10"
+              value={upper}
+              min={lower2}
+              onChange={setU}
+              precision={0}
               id="upperBound"
             >
               <NumberInputField />
@@ -167,10 +180,11 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
             </NumberInput>
           </Stack>
         </FormControl>
+        </Stack>
 
         <Stack 
           id="labels"
-          spacing={{ base: 4, md: 4 }}
+          spacing={{ base: 4, md: 6 }}
           style={{display: "none"}}
         >
           <Heading size="md"> Assign labels to your discrete rating system</Heading>

--- a/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
+++ b/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
@@ -1,0 +1,119 @@
+import { 
+    Input, 
+    Radio, 
+    Stack, 
+    Button,
+    Heading,
+    FormControl, 
+    FormLabel,
+    FormErrorMessage,
+    FormHelperText,
+    RadioGroup
+} from "@chakra-ui/react";
+
+import * as React from 'react';
+import{ Formik, Form, Field, useFormik } from "formik";
+import * as Yup from 'yup';
+
+// name: String!
+// type: String!
+// lowerBound: Int!
+// upperBound: Int!
+// labels: [String!]!
+// subrating: String!
+// subratings: [Subrating!]!
+
+const CreateRatingSystemForm: React.FC<{}> = () => {
+
+    const validationSchema = Yup.object({
+        name: Yup.string()
+          .min(3, 'Name must be at least 3 characters long')
+          .max(20, 'Name must be at most 20 characters long')
+          .required('Required'),
+        type: Yup.string() // Either DISCRETE or CONTINUOUS
+          .required('Required'),
+        lowerBound: Yup.number()
+          .required('Required'),
+        upperBound: Yup.number()
+          .required('Required'),
+        labels: Yup.array() // Array of Strings 
+          .required('Required'),
+        subrating: Yup.string() // Either Yes or No to create custom subratings
+          .oneOf(["Yes", "No"])
+          .required('Required'),
+        subratings: Yup.array() // Array of Subrating objects
+          .required('Required'),
+      });
+
+    const formik = useFormik({
+      initialValues:{
+        name: "",
+        type: "",
+        lowerBound: 0,
+        upperBound: 10,
+        labels: [],
+        subrating: "No",
+        subratings: [],
+      },
+      validationSchema,
+      onSubmit: (values, actions) => {
+        actions.setSubmitting(true);
+
+      }
+    });
+
+    return(
+
+      <form onSubmit={formik.handleSubmit} id="createRatingSystem">
+
+        <FormControl isInvalid={formik.errors.name && formik.touched.name} isRequired>
+          <FormLabel>Name</FormLabel>
+          <Input placeholder="MyRatingSystem" id="name"/>
+        </FormControl>
+    
+        <FormControl isInvalid={formik.errors.type && formik.touched.type} isRequired>
+          <FormLabel>Type of rating system</FormLabel>
+          <RadioGroup>
+            <Stack>
+              <Radio id="CONTINUOUS">Continuous</Radio>
+              <Radio id="DISCRETE">Discrete</Radio>
+            </Stack>
+          </RadioGroup>
+        </FormControl>
+    
+        <FormControl isRequired>
+          <Heading>Customize the range</Heading>
+          <Stack>
+            <FormLabel>Lower bound</FormLabel>
+            <Input id="lowerBound"placeholder="0"/>
+            <FormLabel>Upper bound</FormLabel>
+            <Input id="upperBound" placeholder="10"/>
+          </Stack>
+        </FormControl>
+    
+        <FormControl isRequired>
+          <FormLabel>Create your own subratings</FormLabel>
+          <RadioGroup>
+            <Stack>
+              <Radio>Yes
+                <FormHelperText>(Must create at least 2)</FormHelperText>
+              </Radio>
+              <Radio>No
+                <FormHelperText>(One will be created for you)</FormHelperText>
+              </Radio>
+            </Stack>
+          </RadioGroup>
+        </FormControl>
+
+        <Button
+          mt={6}
+          isLoading={formik.isSubmitting}
+          type="submit"
+        >
+        Create Rating System
+        </Button>
+      </form>
+    );
+};
+
+export default CreateRatingSystemForm;

--- a/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
+++ b/client/src/components/ratingsystem/CreateRatingSystemForm.tsx
@@ -10,7 +10,12 @@ import {
     FormErrorMessage,
     FormHelperText,
     RadioGroup,
-    Center
+    Center,
+    NumberDecrementStepper,
+    NumberIncrementStepper,
+    NumberInput,
+    NumberInputField,
+    NumberInputStepper
 } from "@chakra-ui/react";
 
 import * as React from 'react';
@@ -24,6 +29,30 @@ import * as Yup from 'yup';
 // labels: [String!]!
 // subrating: String!
 // subratings: [Subrating!]!
+
+function showLabels(){
+  // For Discrete Rating System
+  var x = document.getElementById("labels") as HTMLElement;
+  x.style.display = "block";
+}
+
+function hideLabels(){
+  // For Continuous Rating System
+  var x = document.getElementById("labels") as HTMLElement;
+    x.style.display = "none";
+}
+
+function showSubratings(){
+  // For Discrete Rating System
+  var x = document.getElementById("subratings") as HTMLElement;
+  x.style.display = "block";
+}
+
+function hideSubratings(){
+  // For Continuous Rating System
+  var x = document.getElementById("subratings") as HTMLElement;
+    x.style.display = "none";
+}
 
 const CreateRatingSystemForm: React.FC<{}> = () => {
 
@@ -64,8 +93,9 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
       }
     });
 
-    const [value, setValue] = React.useState("1");
-    const [value2, setValue2] = React.useState("1");
+    // Temp values for radios
+    const [valueType, setValueType] = React.useState("1");
+    const [valueSub, setValueSub] = React.useState("1");
 
     return(
 
@@ -73,23 +103,39 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
         <Stack
           spacing={{ base: 8, md: 8 }}
         >
-        <FormControl isInvalid={formik.errors.name && formik.touched.name} isRequired>
+        <FormControl isRequired>
           <FormLabel>Name</FormLabel>
           <Input placeholder="MyRatingSystem" id="name"/>
         </FormControl>
     
-        <FormControl isInvalid={formik.errors.type && formik.touched.type} isRequired>
-          <Stack spacing="24px">
+        <FormControl>
+          <Stack
+            spacing="16px"
+            maxW="lg"
+          >
             <FormLabel>Type of rating system</FormLabel>
-            <RadioGroup onChange={setValue} value={value}>
-              <Stack spacing="24px">
-                <Radio value="1" id="CONTINUOUS">Continuous</Radio>
-                <Radio value="2" id="DISCRETE">Discrete</Radio>
+            <RadioGroup id="type" onChange={setValueType} value={valueType}>
+              <Stack spacing="16px">
+                <Radio
+                  size="lg" 
+                  onChange={hideLabels} 
+                  value="1" 
+                  name="CONTINUOUS"
+                >
+                  Continuous
+                </Radio>
+                <Radio 
+                  size="lg" 
+                  onChange={showLabels} 
+                  value="2" 
+                  name="DISCRETE"
+                >
+                  Discrete
+                </Radio>
               </Stack>
             </RadioGroup>
           </Stack>
         </FormControl>
-        
     
         <FormControl>
           <Stack spacing="24px">
@@ -97,25 +143,92 @@ const CreateRatingSystemForm: React.FC<{}> = () => {
             Customize the range</Heading>
           
             <FormLabel>Lower bound</FormLabel>
-            <Input id="lowerBound" placeholder="0" isInvalid={formik.errors.lowerBound && formik.touched.lowerBound} isRequired/>
+            <NumberInput
+              defaultValue="0"
+              id="lowerBound"
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+
             <FormLabel>Upper bound</FormLabel>
-            <Input id="upperBound" placeholder="10" isInvalid={formik.errors.upperBound && formik.touched.upperBound} isRequired/>
+            <NumberInput
+              defaultValue="10"
+              id="upperBound"
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
           </Stack>
         </FormControl>
+
+        <Stack 
+          id="labels"
+          spacing={{ base: 4, md: 4 }}
+          style={{display: "none"}}
+        >
+          <Heading size="md"> Assign labels to your discrete rating system</Heading>
+          <Button
+            mt={6}
+            type="button"
+            maxW="200px"
+            padding="15px"
+          >
+            Assign Labels
+          </Button>
+        </Stack>
     
-        <FormControl isRequired>
-          <FormLabel>Create your own subratings?</FormLabel>
-          <RadioGroup onChange={setValue2} value={value2}>
-            <Stack>
-              <Radio value="1">Yes
-                <FormHelperText>(Must create at least 2)</FormHelperText>
-              </Radio>
-              <Radio value="2">No
-                <FormHelperText>(One will be created for you)</FormHelperText>
-              </Radio>
-            </Stack>
-          </RadioGroup>
+        <FormControl>
+          <Stack
+            spacing="16px"
+            maxW="lg"
+          >
+            <FormLabel>Create your own subratings?</FormLabel>
+            <RadioGroup onChange={setValueSub} value={valueSub}>
+              <Stack>
+                <Radio 
+                  value="1"
+                  size="lg" 
+                  onChange={hideSubratings}
+                >
+                  No
+                </Radio>
+                <FormHelperText px={{ md: 7 }}>(One will be created for you)</FormHelperText>
+
+                <Radio 
+                  size="lg" 
+                  value="2"
+                  onChange={showSubratings}
+                >
+                  Yes
+                </Radio>
+                <FormHelperText px={{ md: 7 }}>(Must create at least 2)</FormHelperText>
+              </Stack>
+            </RadioGroup>
+          </Stack>
         </FormControl>
+
+        <Stack 
+          id="subratings"
+          spacing={{ base: 4, md: 4 }}
+          style={{display: "none"}}
+        >
+          <Heading size="md"> Create your own subratings</Heading>
+          <Button
+            mt={6}
+            type="button"
+            maxW="200px"
+            padding="15px"
+          >
+            Create Subratings
+          </Button>
+        </Stack>
 
         <Center>
           <Button

--- a/client/src/pages/createratingsystem.tsx
+++ b/client/src/pages/createratingsystem.tsx
@@ -8,7 +8,7 @@ const Signup: React.FC<{}> = () => {
     <Stack
       as={Container}
       spacing={{ base: 8, md: 14 }}
-      py={{ base: 20, md: 36 }}
+      py={{ base: 20, md: 20 }}
       maxWidth="3xl"
     >
       <Heading>

--- a/client/src/pages/createratingsystem.tsx
+++ b/client/src/pages/createratingsystem.tsx
@@ -12,7 +12,7 @@ const CreateRatingSystem: React.FC<{}> = () => {
       maxWidth="3xl"
     >
       <Heading>
-        Create a Rating System
+        Create Your Own Rating System
       </Heading>
       <CreateRatingSystemForm/>
     </Stack>

--- a/client/src/pages/createratingsystem.tsx
+++ b/client/src/pages/createratingsystem.tsx
@@ -1,8 +1,29 @@
-import { Heading, Container, Stack } from "@chakra-ui/react";
+import { Center, Spinner, Heading, Container, Stack } from "@chakra-ui/react";
 import * as React from 'react';
 import CreateRatingSystemForm from "../components/ratingsystem/CreateRatingSystemForm";
+import { useMeQuery } from '../generated/graphql';
+import { useRouter } from "next/router";
 
 const CreateRatingSystem: React.FC<{}> = () => {
+
+  const { data, loading } = useMeQuery();
+  const router = useRouter();
+
+  if (loading) { 
+    return (
+      <Center
+        flexGrow={1}
+      >
+        <Spinner />
+      </Center>
+    );
+  }
+
+  if (!data || !data.me) {
+    router.push("/login");
+
+    return (<div />);
+  }
 
   return (
     <Stack

--- a/client/src/pages/createratingsystem.tsx
+++ b/client/src/pages/createratingsystem.tsx
@@ -1,0 +1,22 @@
+import { Heading, Container, Stack } from "@chakra-ui/react";
+import * as React from 'react';
+import CreateRatingSystemForm from "../components/ratingsystem/CreateRatingSystemForm";
+
+const Signup: React.FC<{}> = () => {
+
+  return (
+    <Stack
+      as={Container}
+      spacing={{ base: 8, md: 14 }}
+      py={{ base: 20, md: 36 }}
+      maxWidth="3xl"
+    >
+      <Heading>
+        Create a Rating System
+      </Heading>
+      <CreateRatingSystemForm/>
+    </Stack>
+  );
+};
+
+export default Signup;

--- a/client/src/pages/createratingsystem.tsx
+++ b/client/src/pages/createratingsystem.tsx
@@ -2,7 +2,7 @@ import { Heading, Container, Stack } from "@chakra-ui/react";
 import * as React from 'react';
 import CreateRatingSystemForm from "../components/ratingsystem/CreateRatingSystemForm";
 
-const Signup: React.FC<{}> = () => {
+const CreateRatingSystem: React.FC<{}> = () => {
 
   return (
     <Stack
@@ -19,4 +19,4 @@ const Signup: React.FC<{}> = () => {
   );
 };
 
-export default Signup;
+export default CreateRatingSystem;

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -5,6 +5,7 @@ import ProfileCard from "../components/profiles/ProfileCard";
 import { MalLinkOauthDocument, MalLinkOauthQuery, useMeQuery } from '../generated/graphql';
 import useImperativeQuery from "../utils/useImperativeQuery";
 import { ApolloQueryResult } from "@apollo/client";
+import Link from "next/link";
 
 const Profile: React.FC<{}> = () => {
   const { data, loading } = useMeQuery();
@@ -41,6 +42,9 @@ const Profile: React.FC<{}> = () => {
         }}>
           Link MAL
         </Button>
+        <Link href="/createratingsystem">
+        <Button colorScheme="blue">Create Rating System</Button>
+        </Link>
       </VStack>
     </Center>
   );


### PR DESCRIPTION
https://user-images.githubusercontent.com/51315588/142507940-abaf0075-3911-4161-aaf8-55c0f5eee161.mp4
Partially closes issue #92 
Creates 2 main issues:
- UI for creating/adding labels
- UI for creating/adding subratings

Additional issues:
- Simple page to let the user know that the rating system has been created and either:
  - Automatically redirects the user to another page
  - Lets the user decide if they want to create another rating system or go back to another page (more on that below)
- Right now, the user can access the create rating system page through the profile page, if we want to change that, we can just move the button to another page