### PR TITLE
rt - profile page GraphQL and Java types

### DIFF
--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/BlockInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/BlockInput.java
@@ -1,0 +1,8 @@
+package com.github.animelist.animelist.model.input.profilepage;
+
+import com.github.animelist.animelist.model.profilepage.BlockType;
+import com.github.animelist.animelist.model.profilepage.Width;
+
+public record BlockInput(Width width, BlockType type,
+    UserListBlockInput userListBlockInput,
+    TextBlockInput textBlockInput) {}

--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/TextBlockInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/TextBlockInput.java
@@ -1,0 +1,3 @@
+package com.github.animelist.animelist.model.input.profilepage;
+
+public record TextBlockInput(String text) {}

--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/UserListBlockInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/UserListBlockInput.java
@@ -1,0 +1,5 @@
+package com.github.animelist.animelist.model.input.profilepage;
+
+import org.bson.types.ObjectId;
+
+public record UserListBlockInput(ObjectId listId, int maxEntries) {}

--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/UserListBlockInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/UserListBlockInput.java
@@ -1,5 +1,3 @@
 package com.github.animelist.animelist.model.input.profilepage;
 
-import org.bson.types.ObjectId;
-
-public record UserListBlockInput(ObjectId listId, int maxEntries) {}
+public record UserListBlockInput(String listId, Integer maxEntries) {}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/Block.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/Block.java
@@ -1,0 +1,52 @@
+package com.github.animelist.animelist.model.profilepage;
+
+public abstract class Block {
+    private Width width;
+    private BlockType type;
+
+    public Block(Width width, BlockType type) {
+        this.width = width;
+        this.type = type;
+    }
+
+    public void setWidth(Width width) {
+        this.width = width;
+    }
+
+    public void setType(BlockType type) {
+        this.type = type;
+    }
+
+    public Width getWidth() {
+        return width;
+    }
+
+    public BlockType getType() {
+        return type;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((width == null) ? 0 : width.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Block other = (Block) obj;
+        if (type != other.type)
+            return false;
+        if (width != other.width)
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/BlockType.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/BlockType.java
@@ -1,0 +1,8 @@
+package com.github.animelist.animelist.model.profilepage;
+
+public enum BlockType {
+    USER_LIST,
+    TEXT,
+    STATISTICS,
+    SPACER
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/SpacerBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/SpacerBlock.java
@@ -1,0 +1,10 @@
+package com.github.animelist.animelist.model.profilepage;
+
+import org.springframework.util.Assert;
+
+public class SpacerBlock extends Block {
+    public SpacerBlock(Width width, BlockType type) {
+        super(width, type);
+        Assert.isTrue(type == BlockType.SPACER, "block type must match class");
+    } 
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlock.java
@@ -1,0 +1,48 @@
+package com.github.animelist.animelist.model.profilepage;
+
+import org.springframework.util.Assert;
+
+public class StatisticsBlock extends Block {
+    private StatisticsBlockAdditionalData additionalData;
+    
+    public StatisticsBlock(Width width, BlockType type,
+        StatisticsBlockAdditionalData additionalData) {
+
+        super(width, type);
+        this.additionalData = additionalData;
+        Assert.isTrue(type == BlockType.STATISTICS, "block type must match class");
+    }
+
+    public StatisticsBlockAdditionalData getAdditionalData() {
+        return additionalData;
+    }
+
+    public void setAdditionalData(StatisticsBlockAdditionalData additionalData) {
+        this.additionalData = additionalData;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((additionalData == null) ? 0 : additionalData.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        StatisticsBlock other = (StatisticsBlock) obj;
+        if (additionalData == null) {
+            if (other.additionalData != null)
+                return false;
+        } else if (!additionalData.equals(other.additionalData))
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlockAdditionalData.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlockAdditionalData.java
@@ -2,9 +2,9 @@ package com.github.animelist.animelist.model.profilepage;
 
 public class StatisticsBlockAdditionalData {
     private int entries;
-    private float avgRating;
+    private Double avgRating;
 
-    public StatisticsBlockAdditionalData(int entries, float avgRating) {
+    public StatisticsBlockAdditionalData(int entries, Double avgRating) {
         this.entries = entries;
         this.avgRating = avgRating;
     }
@@ -17,11 +17,11 @@ public class StatisticsBlockAdditionalData {
         this.entries = entries;
     }
 
-    public float getAvgRating() {
+    public Double getAvgRating() {
         return avgRating;
     }
 
-    public void setAvgRating(float avgRating) {
+    public void setAvgRating(Double avgRating) {
         this.avgRating = avgRating;
     }
 
@@ -29,7 +29,7 @@ public class StatisticsBlockAdditionalData {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + Float.floatToIntBits(avgRating);
+        result = prime * result + ((avgRating == null) ? 0 : avgRating.hashCode());
         result = prime * result + entries;
         return result;
     }
@@ -43,7 +43,10 @@ public class StatisticsBlockAdditionalData {
         if (getClass() != obj.getClass())
             return false;
         StatisticsBlockAdditionalData other = (StatisticsBlockAdditionalData) obj;
-        if (Float.floatToIntBits(avgRating) != Float.floatToIntBits(other.avgRating))
+        if (avgRating == null) {
+            if (other.avgRating != null)
+                return false;
+        } else if (!avgRating.equals(other.avgRating))
             return false;
         if (entries != other.entries)
             return false;

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlockAdditionalData.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlockAdditionalData.java
@@ -1,0 +1,52 @@
+package com.github.animelist.animelist.model.profilepage;
+
+public class StatisticsBlockAdditionalData {
+    private int entries;
+    private float avgRating;
+
+    public StatisticsBlockAdditionalData(int entries, float avgRating) {
+        this.entries = entries;
+        this.avgRating = avgRating;
+    }
+
+    public int getEntries() {
+        return entries;
+    }
+
+    public void setEntries(int entries) {
+        this.entries = entries;
+    }
+
+    public float getAvgRating() {
+        return avgRating;
+    }
+
+    public void setAvgRating(float avgRating) {
+        this.avgRating = avgRating;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Float.floatToIntBits(avgRating);
+        result = prime * result + entries;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        StatisticsBlockAdditionalData other = (StatisticsBlockAdditionalData) obj;
+        if (Float.floatToIntBits(avgRating) != Float.floatToIntBits(other.avgRating))
+            return false;
+        if (entries != other.entries)
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlock.java
@@ -1,0 +1,46 @@
+package com.github.animelist.animelist.model.profilepage;
+
+import org.springframework.util.Assert;
+
+public class TextBlock extends Block {
+    private TextBlockSettings textBlockInput;
+    
+    public TextBlock(Width width, BlockType type, TextBlockSettings textBlockInput) {
+        super(width, type);
+        this.textBlockInput = textBlockInput;
+        Assert.isTrue(type == BlockType.TEXT, "block type must match class");
+    }
+
+    public TextBlockSettings getTextBlockInput() {
+        return textBlockInput;
+    }
+
+    public void setTextBlockInput(TextBlockSettings textBlockInput) {
+        this.textBlockInput = textBlockInput;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((textBlockInput == null) ? 0 : textBlockInput.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TextBlock other = (TextBlock) obj;
+        if (textBlockInput == null) {
+            if (other.textBlockInput != null)
+                return false;
+        } else if (!textBlockInput.equals(other.textBlockInput))
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlockSettings.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlockSettings.java
@@ -1,0 +1,42 @@
+package com.github.animelist.animelist.model.profilepage;
+
+public class TextBlockSettings {
+    private String text;
+
+    public TextBlockSettings(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((text == null) ? 0 : text.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TextBlockSettings other = (TextBlockSettings) obj;
+        if (text == null) {
+            if (other.text != null)
+                return false;
+        } else if (!text.equals(other.text))
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlock.java
@@ -1,0 +1,66 @@
+package com.github.animelist.animelist.model.profilepage;
+
+import org.springframework.util.Assert;
+
+public class UserListBlock extends Block {
+    private UserListBlockSettings userListBlockInput;
+    private UserListBlockAdditionalData additionalData;
+    
+    public UserListBlock(Width width, BlockType type,
+        UserListBlockSettings userListBlockInput,
+        UserListBlockAdditionalData additionalData) {
+
+        super(width, type);
+        this.userListBlockInput = userListBlockInput;
+        this.additionalData = additionalData;
+
+        Assert.isTrue(type == BlockType.USER_LIST, "block type must match class");
+    }
+
+    public UserListBlockSettings getUserListBlockInput() {
+        return userListBlockInput;
+    }
+
+    public void setUserListBlockInput(UserListBlockSettings userListBlockInput) {
+        this.userListBlockInput = userListBlockInput;
+    }
+
+    public UserListBlockAdditionalData getAdditionalData() {
+        return additionalData;
+    }
+
+    public void setAdditionalData(UserListBlockAdditionalData additionalData) {
+        this.additionalData = additionalData;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((additionalData == null) ? 0 : additionalData.hashCode());
+        result = prime * result + ((userListBlockInput == null) ? 0 : userListBlockInput.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UserListBlock other = (UserListBlock) obj;
+        if (additionalData == null) {
+            if (other.additionalData != null)
+                return false;
+        } else if (!additionalData.equals(other.additionalData))
+            return false;
+        if (userListBlockInput == null) {
+            if (other.userListBlockInput != null)
+                return false;
+        } else if (!userListBlockInput.equals(other.userListBlockInput))
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockAdditionalData.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockAdditionalData.java
@@ -1,0 +1,44 @@
+package com.github.animelist.animelist.model.profilepage;
+
+import com.github.animelist.animelist.model.userlist.UserList;
+
+public class UserListBlockAdditionalData {
+    private UserList userList;
+
+    public UserListBlockAdditionalData(UserList userList) {
+        this.userList = userList;
+    }
+
+    public UserList getUserList() {
+        return userList;
+    }
+
+    public void setUserList(UserList userList) {
+        this.userList = userList;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((userList == null) ? 0 : userList.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UserListBlockAdditionalData other = (UserListBlockAdditionalData) obj;
+        if (userList == null) {
+            if (other.userList != null)
+                return false;
+        } else if (!userList.equals(other.userList))
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
@@ -1,29 +1,28 @@
 package com.github.animelist.animelist.model.profilepage;
 
-import org.bson.types.ObjectId;
 
 public class UserListBlockSettings {
-    private ObjectId listId;
-    private int maxEntries;
+    private String listId;
+    private Integer maxEntries;
     
-    public UserListBlockSettings(ObjectId listId, int maxEntries) {
+    public UserListBlockSettings(String listId, Integer maxEntries) {
         this.listId = listId;
         this.maxEntries = maxEntries;
     }
 
-    public ObjectId getListId() {
+    public String getListId() {
         return listId;
     }
 
-    public void setListId(ObjectId listId) {
+    public void setListId(String listId) {
         this.listId = listId;
     }
 
-    public int getMaxEntries() {
+    public Integer getMaxEntries() {
         return maxEntries;
     }
 
-    public void setMaxEntries(int maxEntries) {
+    public void setMaxEntries(Integer maxEntries) {
         this.maxEntries = maxEntries;
     }
 
@@ -32,7 +31,7 @@ public class UserListBlockSettings {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((listId == null) ? 0 : listId.hashCode());
-        result = prime * result + maxEntries;
+        result = prime * result + ((maxEntries == null) ? 0 : maxEntries.hashCode());
         return result;
     }
 
@@ -50,7 +49,10 @@ public class UserListBlockSettings {
                 return false;
         } else if (!listId.equals(other.listId))
             return false;
-        if (maxEntries != other.maxEntries)
+        if (maxEntries == null) {
+            if (other.maxEntries != null)
+                return false;
+        } else if (!maxEntries.equals(other.maxEntries))
             return false;
         return true;
     }

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
@@ -1,0 +1,57 @@
+package com.github.animelist.animelist.model.profilepage;
+
+import org.bson.types.ObjectId;
+
+public class UserListBlockSettings {
+    private ObjectId listId;
+    private int maxEntries;
+    
+    public UserListBlockSettings(ObjectId listId, int maxEntries) {
+        this.listId = listId;
+        this.maxEntries = maxEntries;
+    }
+
+    public ObjectId getListId() {
+        return listId;
+    }
+
+    public void setListId(ObjectId listId) {
+        this.listId = listId;
+    }
+
+    public int getMaxEntries() {
+        return maxEntries;
+    }
+
+    public void setMaxEntries(int maxEntries) {
+        this.maxEntries = maxEntries;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((listId == null) ? 0 : listId.hashCode());
+        result = prime * result + maxEntries;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UserListBlockSettings other = (UserListBlockSettings) obj;
+        if (listId == null) {
+            if (other.listId != null)
+                return false;
+        } else if (!listId.equals(other.listId))
+            return false;
+        if (maxEntries != other.maxEntries)
+            return false;
+        return true;
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/Width.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/Width.java
@@ -1,0 +1,5 @@
+package com.github.animelist.animelist.model.profilepage;
+
+public enum Width {
+    FULL 
+}

--- a/server/src/main/resources/graphql/profilePageSchema.graphqls
+++ b/server/src/main/resources/graphql/profilePageSchema.graphqls
@@ -1,0 +1,77 @@
+interface Block {
+  width: Width!
+  type: BlockType!
+}
+
+type UserListBlock implements Block {
+  width: Width!
+  type: BlockType!
+  userListBlockInput: UserListBlockSettings!
+  additionalData: UserListBlockAdditionalData!
+}
+
+type UserListBlockSettings {
+  listId: ID!
+  maxEntries: Int
+}
+
+type UserListBlockAdditionalData {
+  userList: UserList!
+}
+
+type TextBlock implements Block {
+  width: Width!
+  type: BlockType!
+  textBlockInput: TextBlockSettings!
+}
+
+type TextBlockSettings {
+  text: String!
+}
+
+type StatisticsBlock implements Block {
+  width: Width!
+  type: BlockType!
+  additionalData: StatisticsBlockAdditionalData!
+}
+
+type StatisticsBlockAdditionalData {
+  entries: Int!
+  avgRating: Int!
+}
+
+type SpacerBlock implements Block {
+  width: Width!
+  type: BlockType!
+}
+
+enum Width {
+  FULL
+}
+
+enum BlockType {
+  USER_LIST
+  TEXT
+  STATISTICS
+  SPACER
+}
+
+input ProfilePageInput {
+  blocks: [[BlockInput!]!]!
+}
+
+input BlockInput {
+  width: Width!
+  type: BlockType!
+  userListBlockInput: UserListBlockInput
+  textBlockInput: TextBlockInput
+}
+
+input UserListBlockInput {
+  listId: ID!
+  maxEntries: Int
+}
+
+input TextBlockInput {
+  text: String!
+}

--- a/server/src/main/resources/graphql/profilePageSchema.graphqls
+++ b/server/src/main/resources/graphql/profilePageSchema.graphqls
@@ -11,7 +11,7 @@ type UserListBlock implements Block {
 }
 
 type UserListBlockSettings {
-  listId: ID!
+  listId: String!
   maxEntries: Int
 }
 
@@ -37,7 +37,7 @@ type StatisticsBlock implements Block {
 
 type StatisticsBlockAdditionalData {
   entries: Int!
-  avgRating: Int!
+  avgRating: Int
 }
 
 type SpacerBlock implements Block {
@@ -68,7 +68,7 @@ input BlockInput {
 }
 
 input UserListBlockInput {
-  listId: ID!
+  listId: String!
   maxEntries: Int
 }
 


### PR DESCRIPTION
In this PR:
* Add the types required for the profile page feature to the GraphQL schema
* Create corresponding Java records or classes for each type

Notes:
* The intended flow for using these classes will be as follows for input:
  * Receive a 2D list of BlockInput objects. 
  * Each object's `type` field determines which `Block` type it corresponds to, e.g. `UserListBlock` or `TextBlock`. 
  * For each object, create the corresponding `Block` type and store it in a 2D list with the same shape as the input list.
  * End up with a 2D list of `Block` objects using polymorphism. Store this list in the user object.
* The intended flow for using these classes will be as follows for output:
  * Fetch the 2D list of `Block` objects from the user document.
  * Return the 2D list of `Block` objects with populated `additionalData` fields.
  * The `additionalData` field on each Block can be populated by a GraphQL handler.

Closes #104. Closes #105.