### PR TITLE
rt - backend changes to support adding user blocks

### DIFF
--- a/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
@@ -31,6 +31,7 @@ public class ProfilePageController {
     public List<List<Block>> updateProfilePageBlocks(
         @Argument final Map<String, Object> args) {
        
+        // workaround to avoid unsuccessful cast from LinkedHashMap to BlockInput
         ObjectMapper mapper = new ObjectMapper();
         ProfilePageInput input = mapper.convertValue(args.get("input"), ProfilePageInput.class);
 

--- a/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
@@ -1,17 +1,21 @@
 package com.github.animelist.animelist.controller;
 
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.animelist.animelist.model.input.profilepage.BlockInput;
 import com.github.animelist.animelist.model.input.profilepage.ProfilePageInput;
 import com.github.animelist.animelist.model.profilepage.Block;
 import com.github.animelist.animelist.service.ProfilePageService;
-import com.github.animelist.animelist.service.UserService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
 
+@Controller
 public class ProfilePageController {
     private final ProfilePageService profilePageService;
 
@@ -25,9 +29,11 @@ public class ProfilePageController {
     @MutationMapping
     @PreAuthorize("isAuthenticated()")
     public List<List<Block>> updateProfilePageBlocks(
-        @Argument("input") final ProfilePageInput input) {
+        @Argument final Map<String, Object> args) {
+       
+        ObjectMapper mapper = new ObjectMapper();
+        ProfilePageInput input = mapper.convertValue(args.get("input"), ProfilePageInput.class);
 
-        profilePageService.setProfilePageBlocks(input.blocks());
-        return profilePageService.getProfilePageBlocks();
+        return profilePageService.updateProfilePageBlocks(input.blocks());
     }
 }

--- a/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.github.animelist.animelist.model.input.profilepage.ProfilePageInput;
 import com.github.animelist.animelist.model.profilepage.Block;
+import com.github.animelist.animelist.service.ProfilePageService;
 import com.github.animelist.animelist.service.UserService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,13 +13,13 @@ import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 public class ProfilePageController {
-    private final UserService userService;
+    private final ProfilePageService profilePageService;
 
     @Autowired
     public ProfilePageController(
-        final UserService userService) {
-
-        this.userService = userService;
+        final ProfilePageService profilePageService) {
+        
+        this.profilePageService = profilePageService;
     }
 
     @MutationMapping
@@ -26,7 +27,7 @@ public class ProfilePageController {
     public List<List<Block>> updateProfilePageBlocks(
         @Argument("input") final ProfilePageInput input) {
 
-        userService.setProfilePageBlocks(input.blocks());
+        profilePageService.setProfilePageBlocks(input.blocks());
         return profilePageService.getProfilePageBlocks();
     }
 }

--- a/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
+++ b/server/src/main/java/com/github/animelist/animelist/controller/ProfilePageController.java
@@ -1,0 +1,32 @@
+package com.github.animelist.animelist.controller;
+
+import java.util.List;
+
+import com.github.animelist.animelist.model.input.profilepage.ProfilePageInput;
+import com.github.animelist.animelist.model.profilepage.Block;
+import com.github.animelist.animelist.service.UserService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+public class ProfilePageController {
+    private final UserService userService;
+
+    @Autowired
+    public ProfilePageController(
+        final UserService userService) {
+
+        this.userService = userService;
+    }
+
+    @MutationMapping
+    @PreAuthorize("isAuthenticated()")
+    public List<List<Block>> updateProfilePageBlocks(
+        @Argument("input") final ProfilePageInput input) {
+
+        userService.setProfilePageBlocks(input.blocks());
+        return profilePageService.getProfilePageBlocks();
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/entity/User.java
+++ b/server/src/main/java/com/github/animelist/animelist/entity/User.java
@@ -86,7 +86,7 @@ public class User extends DateAudit {
         return profilePageBlocks;
     }
 
-    void setProfilePageBlocks(List<List<Block>> profilePageBlocks) {
+    public void setProfilePageBlocks(List<List<Block>> profilePageBlocks) {
         this.profilePageBlocks = profilePageBlocks; 
     }
 

--- a/server/src/main/java/com/github/animelist/animelist/entity/User.java
+++ b/server/src/main/java/com/github/animelist/animelist/entity/User.java
@@ -1,9 +1,9 @@
 package com.github.animelist.animelist.entity;
 
+import com.github.animelist.animelist.model.profilepage.Block;
 import com.github.animelist.animelist.model.ratingsystem.EmbeddedRatingSystem;
 import com.github.animelist.animelist.model.user.UserListEntry;
 import com.github.animelist.animelist.model.userlist.EmbeddedUserList;
-import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -23,6 +23,8 @@ public class User extends DateAudit {
 
     private String password;
 
+    private List<List<Block>> profilePageBlocks;
+
     private List<EmbeddedUserList> userLists;
 
     private List<EmbeddedRatingSystem> ratingSystems;
@@ -41,6 +43,7 @@ public class User extends DateAudit {
         this.username = username;
         this.email = email;
         this.password = password;
+        this.profilePageBlocks = new ArrayList<List<Block>>();
         this.userList = new ArrayList<>();
     }
 
@@ -77,6 +80,14 @@ public class User extends DateAudit {
 
     public void setPassword(final String password) {
         this.password = password;
+    }
+
+    public List<List<Block>> getProfilePageBlocks() {
+        return profilePageBlocks;
+    }
+
+    void setProfilePageBlocks(List<List<Block>> profilePageBlocks) {
+        this.profilePageBlocks = profilePageBlocks; 
     }
 
     public List<UserListEntry> getUserList() {

--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/BlockInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/BlockInput.java
@@ -5,4 +5,13 @@ import com.github.animelist.animelist.model.profilepage.Width;
 
 public record BlockInput(Width width, BlockType type,
     UserListBlockInput userListBlockInput,
-    TextBlockInput textBlockInput) {}
+    TextBlockInput textBlockInput) {
+
+    public BlockInput(Width width, BlockType type) {
+        this(width, type, null, null);
+    }
+
+    public BlockInput(Width width, BlockType type, UserListBlockInput userListBlockInput) {
+        this(width, type, userListBlockInput, null);
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/BlockInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/BlockInput.java
@@ -6,12 +6,4 @@ import com.github.animelist.animelist.model.profilepage.Width;
 public record BlockInput(Width width, BlockType type,
     UserListBlockInput userListBlockInput,
     TextBlockInput textBlockInput) {
-
-    public BlockInput(Width width, BlockType type) {
-        this(width, type, null, null);
-    }
-
-    public BlockInput(Width width, BlockType type, UserListBlockInput userListBlockInput) {
-        this(width, type, userListBlockInput, null);
-    }
 }

--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/ProfilePageInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/ProfilePageInput.java
@@ -1,6 +1,6 @@
 package com.github.animelist.animelist.model.input.profilepage;
 
 import java.util.List;
-import com.github.animelist.animelist.model.profilepage.Block;
+import com.github.animelist.animelist.model.input.profilepage.BlockInput;
 
-public record ProfilePageInput(List<List<Block>> blocks) {}
+public record ProfilePageInput(List<List<BlockInput>> blocks) {}

--- a/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/ProfilePageInput.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/input/profilepage/ProfilePageInput.java
@@ -1,0 +1,6 @@
+package com.github.animelist.animelist.model.input.profilepage;
+
+import java.util.List;
+import com.github.animelist.animelist.model.profilepage.Block;
+
+public record ProfilePageInput(List<List<Block>> blocks) {}

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlock.java
@@ -1,5 +1,6 @@
 package com.github.animelist.animelist.model.profilepage;
 
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.util.Assert;
 
 public class StatisticsBlock extends Block {
@@ -13,6 +14,7 @@ public class StatisticsBlock extends Block {
         Assert.isTrue(type == BlockType.STATISTICS, "block type must match class");
     }
 
+    @PersistenceConstructor
     public StatisticsBlock(Width width, BlockType type) {
         this(width, type, null);
     }

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/StatisticsBlock.java
@@ -13,6 +13,10 @@ public class StatisticsBlock extends Block {
         Assert.isTrue(type == BlockType.STATISTICS, "block type must match class");
     }
 
+    public StatisticsBlock(Width width, BlockType type) {
+        this(width, type, null);
+    }
+
     public StatisticsBlockAdditionalData getAdditionalData() {
         return additionalData;
     }

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlockSettings.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlockSettings.java
@@ -2,9 +2,12 @@ package com.github.animelist.animelist.model.profilepage;
 
 import com.github.animelist.animelist.model.input.profilepage.TextBlockInput;
 
+import org.springframework.data.annotation.PersistenceConstructor;
+
 public class TextBlockSettings {
     private String text;
 
+    @PersistenceConstructor
     public TextBlockSettings(String text) {
         this.text = text;
     }

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlockSettings.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/TextBlockSettings.java
@@ -1,10 +1,16 @@
 package com.github.animelist.animelist.model.profilepage;
 
+import com.github.animelist.animelist.model.input.profilepage.TextBlockInput;
+
 public class TextBlockSettings {
     private String text;
 
     public TextBlockSettings(String text) {
         this.text = text;
+    }
+
+    public TextBlockSettings(TextBlockInput input) {
+        this(input.text());
     }
 
     public String getText() {

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlock.java
@@ -1,5 +1,6 @@
 package com.github.animelist.animelist.model.profilepage;
 
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.util.Assert;
 
 public class UserListBlock extends Block {
@@ -17,6 +18,7 @@ public class UserListBlock extends Block {
         Assert.isTrue(type == BlockType.USER_LIST, "block type must match class");
     }
 
+    @PersistenceConstructor
     public UserListBlock(Width width, BlockType type,
         UserListBlockSettings userListBlockInput) {
         

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlock.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlock.java
@@ -17,6 +17,12 @@ public class UserListBlock extends Block {
         Assert.isTrue(type == BlockType.USER_LIST, "block type must match class");
     }
 
+    public UserListBlock(Width width, BlockType type,
+        UserListBlockSettings userListBlockInput) {
+        
+        this(width, type, userListBlockInput, null);
+    }
+
     public UserListBlockSettings getUserListBlockInput() {
         return userListBlockInput;
     }

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
@@ -1,5 +1,6 @@
 package com.github.animelist.animelist.model.profilepage;
 
+import com.github.animelist.animelist.model.input.profilepage.UserListBlockInput;
 
 public class UserListBlockSettings {
     private String listId;
@@ -8,6 +9,10 @@ public class UserListBlockSettings {
     public UserListBlockSettings(String listId, Integer maxEntries) {
         this.listId = listId;
         this.maxEntries = maxEntries;
+    }
+
+    public UserListBlockSettings(UserListBlockInput input) {
+        this(input.listId(), input.maxEntries());
     }
 
     public String getListId() {

--- a/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
+++ b/server/src/main/java/com/github/animelist/animelist/model/profilepage/UserListBlockSettings.java
@@ -2,10 +2,13 @@ package com.github.animelist.animelist.model.profilepage;
 
 import com.github.animelist.animelist.model.input.profilepage.UserListBlockInput;
 
+import org.springframework.data.annotation.PersistenceConstructor;
+
 public class UserListBlockSettings {
     private String listId;
     private Integer maxEntries;
-    
+   
+    @PersistenceConstructor
     public UserListBlockSettings(String listId, Integer maxEntries) {
         this.listId = listId;
         this.maxEntries = maxEntries;

--- a/server/src/main/java/com/github/animelist/animelist/service/ProfilePageService.java
+++ b/server/src/main/java/com/github/animelist/animelist/service/ProfilePageService.java
@@ -1,0 +1,65 @@
+package com.github.animelist.animelist.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.github.animelist.animelist.entity.User;
+import com.github.animelist.animelist.model.JwtUserDetails;
+import com.github.animelist.animelist.model.input.profilepage.BlockInput;
+import com.github.animelist.animelist.model.profilepage.Block;
+import com.github.animelist.animelist.model.profilepage.SpacerBlock;
+import com.github.animelist.animelist.model.profilepage.StatisticsBlock;
+import com.github.animelist.animelist.model.profilepage.TextBlock;
+import com.github.animelist.animelist.model.profilepage.TextBlockSettings;
+import com.github.animelist.animelist.model.profilepage.UserListBlock;
+import com.github.animelist.animelist.model.profilepage.UserListBlockSettings;
+
+import static com.github.animelist.animelist.util.AuthUtil.getUserDetails;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProfilePageService {
+    private final UserService userService;
+
+    @Autowired
+    public ProfilePageService(final UserService userService) {
+        this.userService = userService;
+    }
+
+    public List<List<Block>> updateProfilePageBlocks(List<List<BlockInput>> blocks) {
+        List<List<Block>> outputBlocks = blocks.stream().map(this::convertRowToFullBlocks)
+            .collect(Collectors.toCollection(ArrayList::new));
+        
+        JwtUserDetails userDetails = getUserDetails();
+        User user = userService.getUser(userDetails.getId())
+            .orElseThrow(() -> new RuntimeException("Can't find user."));
+        user.setProfilePageBlocks(outputBlocks);
+
+        return outputBlocks;
+    }
+
+    private List<Block> convertRowToFullBlocks(List<BlockInput> row) {
+        return row.stream().map(this::convertToFullBlock)
+            .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private Block convertToFullBlock(BlockInput blockInput) {
+        switch (blockInput.type()) {
+            case USER_LIST:
+                return new UserListBlock(blockInput.width(), blockInput.type(),
+                    new UserListBlockSettings(blockInput.userListBlockInput()));
+            case TEXT:
+                return new TextBlock(blockInput.width(), blockInput.type(),
+                    new TextBlockSettings(blockInput.textBlockInput()));
+            case STATISTICS:
+                return new StatisticsBlock(blockInput.width(), blockInput.type());
+            case SPACER:
+                return new SpacerBlock(blockInput.width(), blockInput.type());
+            default:
+                // this case will never be reached since the above cases cover all
+                // possible enum values, but this needs to be here to keep compiler happy
+                return new SpacerBlock(blockInput.width(), blockInput.type());
+        }
+    }
+}

--- a/server/src/main/java/com/github/animelist/animelist/service/ProfilePageService.java
+++ b/server/src/main/java/com/github/animelist/animelist/service/ProfilePageService.java
@@ -18,7 +18,9 @@ import com.github.animelist.animelist.model.profilepage.UserListBlockSettings;
 import static com.github.animelist.animelist.util.AuthUtil.getUserDetails;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ProfilePageService {
     private final UserService userService;
 
@@ -35,6 +37,7 @@ public class ProfilePageService {
         User user = userService.getUser(userDetails.getId())
             .orElseThrow(() -> new RuntimeException("Can't find user."));
         user.setProfilePageBlocks(outputBlocks);
+        userService.updateUser(user);
 
         return outputBlocks;
     }

--- a/server/src/main/resources/graphql/schema.graphqls
+++ b/server/src/main/resources/graphql/schema.graphqls
@@ -69,4 +69,5 @@ type Mutation {
   createUserList(input: CreateUserListInput!): UserList
   addUserListItem(input: AddUserListItemInput!): UserListItem
   updateUserListItem(input: UpdateUserListItemInput!): UserListItem
+  updateProfilePageBlocks(input: ProfilePageInput): [[Block!]!]!
 }

--- a/server/src/main/resources/graphql/schema.graphqls
+++ b/server/src/main/resources/graphql/schema.graphqls
@@ -69,5 +69,5 @@ type Mutation {
   createUserList(input: CreateUserListInput!): UserList
   addUserListItem(input: AddUserListItemInput!): UserListItem
   updateUserListItem(input: UpdateUserListItemInput!): UserListItem
-  updateProfilePageBlocks(input: ProfilePageInput): [[Block!]!]!
+  updateProfilePageBlocks(input: ProfilePageInput!): [[Block!]!]!
 }

--- a/server/src/main/resources/graphql/schema.graphqls
+++ b/server/src/main/resources/graphql/schema.graphqls
@@ -3,6 +3,7 @@ scalar DateTime
 type User {
   id: ID!
   username: String!
+  profilePageBlocks: [[Block!]!]!
   userList: [UserListEntry!]!
   userLists: [EmbeddedUserList]
   ratingSystems: [EmbeddedRatingSystem]


### PR DESCRIPTION
In this PR:
* Add the `profilePageBlocks` field to the User type.
* Add a new `updateProfilePageBlocks` root mutation that takes a 2D array of `BlockInput` objects and uses it to populate the `profilePageBlocks` field for the current user.
* Add the necessary constructors to all of the persisted data types (marked with `@PersistenceConstructor` annotation) to allow restoring them from database.

Closes #106. Closes #107.