### PR TITLE
jv/rt - display blocks on profile page

### DIFF
--- a/client/src/components/list/_UserList.tsx
+++ b/client/src/components/list/_UserList.tsx
@@ -14,6 +14,7 @@ const PAGE_SIZE = 20;
 export interface UserListProps {
   userlist: UserListType;
   isOwn: boolean;
+  fullSize: boolean;
 }
 
 export interface IListItem {
@@ -56,7 +57,7 @@ export const ListOwnerBar: React.FC<{ addedIds: Set<number>; listId: string }> =
   );
 };
 
-const UserList: React.FC<UserListProps> = ({ userlist, isOwn }) => {
+const UserList: React.FC<UserListProps> = ({ userlist, isOwn, fullSize }) => {
   const MAX_PAGE = Math.ceil(userlist.items.length / PAGE_SIZE)
   const [listItems, setListItems] = useState<IListItem[]>([])
   const [page, setPage] = useState<number>(1);

--- a/client/src/components/list/_UserList.tsx
+++ b/client/src/components/list/_UserList.tsx
@@ -126,7 +126,7 @@ const UserList: React.FC<UserListProps> = ({ userlist, isOwn, fullSize }) => {
           <Tr>
             {fullSize && <Th>Image</Th>}
             <Th>Anime title</Th>
-            <Th>Watch Status</Th>
+            <Th display={{ base: "none", md: "table-cell" }}>Watch Status</Th>
             <Th>Rating</Th>
             {isOwn && <Th />}
           </Tr>

--- a/client/src/components/list/_UserList.tsx
+++ b/client/src/components/list/_UserList.tsx
@@ -116,13 +116,15 @@ const UserList: React.FC<UserListProps> = ({ userlist, isOwn, fullSize }) => {
   }
 
   return (
-    <VStack width="full" p={6}>
-      <Heading>{userlist.name}</Heading>
+    <VStack width="full" p={fullSize ? 6 : 0}>
+      <Heading size={fullSize ? 'xl' : 'md'} alignSelf={fullSize ? 'center' : 'flex-start'}>
+        {userlist.name}
+      </Heading>
       {isOwn && <ListOwnerBar addedIds={new Set(userlist.items.map(item => item.mediaID))} listId={userlist.id} />}
       <Table>
         <Thead>
           <Tr>
-            <Th>Image</Th>
+            {fullSize && <Th>Image</Th>}
             <Th>Anime title</Th>
             <Th>Watch Status</Th>
             <Th>Rating</Th>
@@ -131,7 +133,7 @@ const UserList: React.FC<UserListProps> = ({ userlist, isOwn, fullSize }) => {
         </Thead>
         <Tbody>
           {
-            listItems.map((item) => <UserListItem key={item.id} item={item} canEdit={isOwn}/>)
+            listItems.map((item) => <UserListItem key={item.id} item={item} canEdit={isOwn} showImage={fullSize} />)
           }
         </Tbody>
       </Table>

--- a/client/src/components/list/_UserListItem.tsx
+++ b/client/src/components/list/_UserListItem.tsx
@@ -8,6 +8,7 @@ import { IListItem } from './_UserList';
 export interface UserListItemProps {
   item: IListItem;
   canEdit: boolean;
+  showImage: boolean;
 }
 
 const badgeFor = (watchStatus: WatchStatus) => {
@@ -27,13 +28,14 @@ const badgeFor = (watchStatus: WatchStatus) => {
   }
 }
 
-const UserListItem: React.FC<UserListItemProps> = ({ item: initialItem, canEdit }) => {
+const UserListItem: React.FC<UserListItemProps> = ({ item: initialItem, canEdit, showImage }) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [item, changeItemState] = React.useState<IListItem>(initialItem);
 
+
   return (
     <Tr>
-      <Td><Image src={item.coverImage} minWidth="67px" width="67px" height="100px" objectFit="cover" /></Td>
+      {showImage && <Td><Image src={item.coverImage} minWidth="67px" width="67px" height="100px" objectFit="cover" /></Td>}
       <Td>{item.title}</Td>
       <Td>{badgeFor(item.watchStatus as WatchStatus)}</Td>
       <Td>{item.rating ? item.rating.displayRating : <Icon as={BsDash} />}</Td>

--- a/client/src/components/list/_UserListItem.tsx
+++ b/client/src/components/list/_UserListItem.tsx
@@ -37,7 +37,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ item: initialItem, canEdit,
     <Tr>
       {showImage && <Td><Image src={item.coverImage} minWidth="67px" width="67px" height="100px" objectFit="cover" /></Td>}
       <Td>{item.title}</Td>
-      <Td>{badgeFor(item.watchStatus as WatchStatus)}</Td>
+      <Td display={{ base: "none", md: "table-cell" }}>{badgeFor(item.watchStatus as WatchStatus)}</Td>
       <Td>{item.rating ? item.rating.displayRating : <Icon as={BsDash} />}</Td>
       { canEdit && <Td><Button onClick={onOpen}>Edit</Button><EditAnimeModal item={item} isOpen={isOpen} onClose={onClose} onSave={changeItemState}/></Td> }
     </Tr>

--- a/client/src/components/profiles/ProfilePageBlock.tsx
+++ b/client/src/components/profiles/ProfilePageBlock.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Block, BlockType } from "../../generated/graphql";
+import { Block, BlockType, SpacerBlock, StatisticsBlock, TextBlock, UserListBlock } from "../../generated/graphql";
 import SpacerBlockDisplay from './SpacerBlockDisplay';
+import StatisticsBlockDisplay from './StatisticsBlockDisplay';
 
 interface Props {
   block: Block;
@@ -9,13 +10,13 @@ interface Props {
 const ProfilePageBlock: React.FC<Props> = ({ block }) => {
   switch (block.type) {
     case BlockType.Spacer:
-      return <SpacerBlockDisplay block={block} />;
+      return <SpacerBlockDisplay block={block as SpacerBlock} />;
     case BlockType.Statistics:
-      return <StatisticsBlock block={block} />;
+      return <StatisticsBlockDisplay block={block as StatisticsBlock} />;
     case BlockType.Text:
-      return <TextBlock block={block} />;
+      return <TextBlockDisplay block={block as TextBlock} />;
     case BlockType.UserList:
-      return <UserListBlock block={block} />;
+      return <UserListBlockDisplay block={block as UserListBlock} />;
   }
 }
 

--- a/client/src/components/profiles/ProfilePageBlock.tsx
+++ b/client/src/components/profiles/ProfilePageBlock.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@chakra-ui/layout';
 import * as React from 'react';
 import { Block, BlockType, SpacerBlock, StatisticsBlock, TextBlock, UserListBlock } from "../../generated/graphql";
 import SpacerBlockDisplay from './SpacerBlockDisplay';
@@ -10,16 +11,32 @@ interface Props {
 }
 
 const ProfilePageBlock: React.FC<Props> = ({ block }) => {
+  let displayedBlock;
+
   switch (block.type) {
     case BlockType.Spacer:
-      return <SpacerBlockDisplay block={block as SpacerBlock} />;
+      displayedBlock = <SpacerBlockDisplay block={block as SpacerBlock} />;
+      break;
     case BlockType.Statistics:
-      return <StatisticsBlockDisplay block={block as StatisticsBlock} />;
+      displayedBlock = <StatisticsBlockDisplay block={block as StatisticsBlock} />;
+      break;
     case BlockType.Text:
-      return <TextBlockDisplay block={block as TextBlock} />;
+      displayedBlock = <TextBlockDisplay block={block as TextBlock} />;
+      break;
     case BlockType.UserList:
-      return <UserListBlockDisplay block={block as UserListBlock} />;
+      displayedBlock = <UserListBlockDisplay block={block as UserListBlock} />;
+      break;
   }
+
+  return (
+    <Box p={6}
+      borderWidth={(block.type !== BlockType.Spacer) ? '1px' : '0'}
+      borderRadius='md'>
+
+      {displayedBlock}
+
+    </Box>
+  );
 }
 
 export default ProfilePageBlock;

--- a/client/src/components/profiles/ProfilePageBlock.tsx
+++ b/client/src/components/profiles/ProfilePageBlock.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Block, BlockType, SpacerBlock, StatisticsBlock, TextBlock, UserListBlock } from "../../generated/graphql";
 import SpacerBlockDisplay from './SpacerBlockDisplay';
 import StatisticsBlockDisplay from './StatisticsBlockDisplay';
+import TextBlockDisplay from './TextBlockDisplay';
+import UserListBlockDisplay from './UserListBlockDisplay';
 
 interface Props {
   block: Block;

--- a/client/src/components/profiles/ProfilePageBlock.tsx
+++ b/client/src/components/profiles/ProfilePageBlock.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Block, BlockType } from "../../generated/graphql";
+import SpacerBlockDisplay from './SpacerBlockDisplay';
+
+interface Props {
+  block: Block;
+}
+
+const ProfilePageBlock: React.FC<Props> = ({ block }) => {
+  switch (block.type) {
+    case BlockType.Spacer:
+      return <SpacerBlockDisplay block={block} />;
+    case BlockType.Statistics:
+      return <StatisticsBlock block={block} />;
+    case BlockType.Text:
+      return <TextBlock block={block} />;
+    case BlockType.UserList:
+      return <UserListBlock block={block} />;
+  }
+}
+
+export default ProfilePageBlock;

--- a/client/src/components/profiles/ProfilePageBlockGrid.tsx
+++ b/client/src/components/profiles/ProfilePageBlockGrid.tsx
@@ -1,0 +1,26 @@
+import { Grid } from "@chakra-ui/react";
+import React from "react";
+import { Block } from "../../generated/graphql";
+import ProfilePageBlock from "./ProfilePageBlock";
+
+interface Props {
+  blocks: Block[][];
+}
+
+const ProfilePageBlockGrid: React.FC<Props> = ({ blocks }) => {
+  return (
+    <Grid
+      width="100%"
+      templateRows='repeat(2, auto)'
+      gap={4}
+    >
+      {
+        blocks.map(row =>
+          <div>{row.map(block => <ProfilePageBlock block={block} />)}</div>
+        )
+      }
+    </Grid>
+  );
+}
+
+export default ProfilePageBlockGrid;

--- a/client/src/components/profiles/ProfilePageBlockGrid.tsx
+++ b/client/src/components/profiles/ProfilePageBlockGrid.tsx
@@ -15,8 +15,8 @@ const ProfilePageBlockGrid: React.FC<Props> = ({ blocks }) => {
       gap={4}
     >
       {
-        blocks.map(row =>
-          <div>{row.map(block => <ProfilePageBlock block={block} />)}</div>
+        blocks.map(row => 
+          row.map(block => <ProfilePageBlock block={block} />)
         )
       }
     </Grid>

--- a/client/src/components/profiles/SpacerBlockDisplay.tsx
+++ b/client/src/components/profiles/SpacerBlockDisplay.tsx
@@ -1,0 +1,15 @@
+import { Box } from '@chakra-ui/layout';
+import * as React from 'react';
+import { SpacerBlock } from '../../generated/graphql';
+
+const SPACER_HEIGHT = 20;
+
+interface Props {
+  block: SpacerBlock;
+}
+
+const SpacerBlockDisplay: React.FC<Props> = ({ block }) => {
+  return <Box w='100%' h={SPACER_HEIGHT} />;
+}
+
+export default SpacerBlockDisplay;

--- a/client/src/components/profiles/StatisticsBlockDisplay.tsx
+++ b/client/src/components/profiles/StatisticsBlockDisplay.tsx
@@ -1,0 +1,22 @@
+import { Box } from '@chakra-ui/layout';
+import { Stat, StatHelpText, StatLabel, StatNumber } from '@chakra-ui/stat';
+import * as React from 'react';
+import { StatisticsBlock } from '../../generated/graphql';
+
+interface Props {
+  block: StatisticsBlock;
+}
+
+const StatisticsBlockDisplay: React.FC<Props> = ({ block }) => {
+  return (
+    <Box w="100%">
+      <Stat>
+        <StatLabel>Media Entries</StatLabel>
+        <StatNumber>{block.additionalData.entries}</StatNumber>
+        <StatHelpText>Unique entries across all lists</StatHelpText>
+      </Stat>
+    </Box> 
+  );
+}
+
+export default StatisticsBlockDisplay;

--- a/client/src/components/profiles/StatisticsBlockDisplay.tsx
+++ b/client/src/components/profiles/StatisticsBlockDisplay.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@chakra-ui/layout';
-import { Stat, StatHelpText, StatLabel, StatNumber } from '@chakra-ui/stat';
+import { Stat, StatGroup, StatHelpText, StatLabel, StatNumber } from '@chakra-ui/stat';
 import * as React from 'react';
 import { StatisticsBlock } from '../../generated/graphql';
 
@@ -10,11 +10,13 @@ interface Props {
 const StatisticsBlockDisplay: React.FC<Props> = ({ block }) => {
   return (
     <Box w="100%">
-      <Stat>
-        <StatLabel>Media Entries</StatLabel>
-        <StatNumber>{block.additionalData.entries}</StatNumber>
-        <StatHelpText>Unique entries across all lists</StatHelpText>
-      </Stat>
+      <StatGroup>
+        <Stat>
+          <StatLabel fontSize='md'>Media Entries</StatLabel>
+          <StatNumber>{block.additionalData.entries}</StatNumber>
+          <StatHelpText>Unique entries across all lists</StatHelpText>
+        </Stat>
+      </StatGroup>
     </Box> 
   );
 }

--- a/client/src/components/profiles/TextBlockDisplay.tsx
+++ b/client/src/components/profiles/TextBlockDisplay.tsx
@@ -1,0 +1,19 @@
+import { Box, Text } from '@chakra-ui/layout';
+import * as React from 'react';
+import { TextBlock } from '../../generated/graphql';
+
+interface Props {
+  block: TextBlock;
+}
+
+const TextBlockDisplay: React.FC<Props> = ({ block }) => {
+  return (
+    <Box w='100%'>
+      <Text>
+        {block.textBlockInput.text}
+      </Text>
+    </Box>
+  )
+}
+
+export default TextBlockDisplay;

--- a/client/src/components/profiles/UserListBlockDisplay.tsx
+++ b/client/src/components/profiles/UserListBlockDisplay.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { UserListBlock } from '../../generated/graphql';
+
+interface Props {
+  block: UserListBlock;
+}
+
+const UserListBlockDisplay: React.FC<Props> = ({ block }) => {
+  return ();
+}
+
+export default UserListBlockDisplay;

--- a/client/src/components/profiles/UserListBlockDisplay.tsx
+++ b/client/src/components/profiles/UserListBlockDisplay.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import UserList from '../../components/list/_UserList';
 import { UserListBlock } from '../../generated/graphql';
 
 interface Props {
@@ -6,7 +7,9 @@ interface Props {
 }
 
 const UserListBlockDisplay: React.FC<Props> = ({ block }) => {
-  return ();
+  return (
+    <UserList userlist={block.additionalData.userList} isOwn={false} fullSize={false} />
+  );
 }
 
 export default UserListBlockDisplay;

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -23,6 +23,25 @@ export type AddUserListItemInput = {
   watchStatus: WatchStatus;
 };
 
+export type Block = {
+  type: BlockType;
+  width: Width;
+};
+
+export type BlockInput = {
+  textBlockInput?: Maybe<TextBlockInput>;
+  type: BlockType;
+  userListBlockInput?: Maybe<UserListBlockInput>;
+  width: Width;
+};
+
+export enum BlockType {
+  Spacer = 'SPACER',
+  Statistics = 'STATISTICS',
+  Text = 'TEXT',
+  UserList = 'USER_LIST'
+}
+
 export type ContinuousRatingSystem = RatingSystem & {
   __typename?: 'ContinuousRatingSystem';
   id: Scalars['ID'];
@@ -96,6 +115,7 @@ export type Mutation = {
   malLink?: Maybe<Scalars['Boolean']>;
   malLogin?: Maybe<LoginResponse>;
   register?: Maybe<RegisterResponse>;
+  updateProfilePageBlocks: Array<Array<Block>>;
   updateUserListEntry?: Maybe<UserListEntry>;
   updateUserListItem?: Maybe<UserListItem>;
 };
@@ -141,6 +161,11 @@ export type MutationRegisterArgs = {
 };
 
 
+export type MutationUpdateProfilePageBlocksArgs = {
+  input: ProfilePageInput;
+};
+
+
 export type MutationUpdateUserListEntryArgs = {
   input: UserListEntryInput;
 };
@@ -148,6 +173,10 @@ export type MutationUpdateUserListEntryArgs = {
 
 export type MutationUpdateUserListItemArgs = {
   input: UpdateUserListItemInput;
+};
+
+export type ProfilePageInput = {
+  blocks: Array<Array<BlockInput>>;
 };
 
 export type Query = {
@@ -202,6 +231,25 @@ export type RegisterResponse = {
   success: Scalars['Boolean'];
 };
 
+export type SpacerBlock = Block & {
+  __typename?: 'SpacerBlock';
+  type: BlockType;
+  width: Width;
+};
+
+export type StatisticsBlock = Block & {
+  __typename?: 'StatisticsBlock';
+  additionalData: StatisticsBlockAdditionalData;
+  type: BlockType;
+  width: Width;
+};
+
+export type StatisticsBlockAdditionalData = {
+  __typename?: 'StatisticsBlockAdditionalData';
+  avgRating?: Maybe<Scalars['Int']>;
+  entries: Scalars['Int'];
+};
+
 export type SubRating = {
   __typename?: 'SubRating';
   id: Scalars['ID'];
@@ -215,6 +263,22 @@ export type SubRatingInput = {
   weight: Scalars['Float'];
 };
 
+export type TextBlock = Block & {
+  __typename?: 'TextBlock';
+  textBlockInput: TextBlockSettings;
+  type: BlockType;
+  width: Width;
+};
+
+export type TextBlockInput = {
+  text: Scalars['String'];
+};
+
+export type TextBlockSettings = {
+  __typename?: 'TextBlockSettings';
+  text: Scalars['String'];
+};
+
 export type UpdateUserListItemInput = {
   listId: Scalars['String'];
   mediaID: Scalars['Int'];
@@ -226,6 +290,7 @@ export type User = {
   __typename?: 'User';
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
+  profilePageBlocks: Array<Array<Block>>;
   ratingSystems?: Maybe<Array<Maybe<EmbeddedRatingSystem>>>;
   updatedAt: Scalars['DateTime'];
   userList: Array<UserListEntry>;
@@ -240,6 +305,30 @@ export type UserList = {
   name: Scalars['String'];
   ownerId: Scalars['String'];
   ratingSystem?: Maybe<RatingSystem>;
+};
+
+export type UserListBlock = Block & {
+  __typename?: 'UserListBlock';
+  additionalData: UserListBlockAdditionalData;
+  type: BlockType;
+  userListBlockInput: UserListBlockSettings;
+  width: Width;
+};
+
+export type UserListBlockAdditionalData = {
+  __typename?: 'UserListBlockAdditionalData';
+  userList: UserList;
+};
+
+export type UserListBlockInput = {
+  listId: Scalars['String'];
+  maxEntries?: Maybe<Scalars['Int']>;
+};
+
+export type UserListBlockSettings = {
+  __typename?: 'UserListBlockSettings';
+  listId: Scalars['String'];
+  maxEntries?: Maybe<Scalars['Int']>;
 };
 
 export type UserListEntry = {
@@ -287,6 +376,10 @@ export enum WatchStatus {
   OnHold = 'ON_HOLD',
   PlanToWatch = 'PLAN_TO_WATCH',
   Watching = 'WATCHING'
+}
+
+export enum Width {
+  Full = 'FULL'
 }
 
 export type _AddUserListItemMutationVariables = Exact<{
@@ -379,12 +472,52 @@ export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type MeQuery = { __typename?: 'Query', me?: Maybe<{ __typename?: 'User', id: string, username: string, ratingSystems?: Maybe<Array<Maybe<{ __typename?: 'EmbeddedRatingSystem', id: string, name: string }>>>, userLists?: Maybe<Array<Maybe<{ __typename?: 'EmbeddedUserList', id: string, name: string }>>> }> };
 
+export type ProfileQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ProfileQuery = { __typename?: 'Query', me?: Maybe<{ __typename?: 'User', username: string, userLists?: Maybe<Array<Maybe<{ __typename?: 'EmbeddedUserList', id: string, name: string }>>>, profilePageBlocks: Array<Array<{ __typename?: 'SpacerBlock', width: Width, type: BlockType } | { __typename?: 'StatisticsBlock', width: Width, type: BlockType, additionalData: { __typename?: 'StatisticsBlockAdditionalData', entries: number } } | { __typename?: 'TextBlock', width: Width, type: BlockType, textBlockInput: { __typename?: 'TextBlockSettings', text: string } } | { __typename?: 'UserListBlock', width: Width, type: BlockType, additionalData: { __typename?: 'UserListBlockAdditionalData', userList: { __typename?: 'UserList', name: string, items?: Maybe<Array<Maybe<{ __typename?: 'UserListItem', mediaID: number, watchStatus: string, rating?: Maybe<{ __typename?: 'UserListRating', displayRating: string }> }>>> } } }>> }> };
+
+export type UserListBlockFieldsFragment = { __typename?: 'UserListBlock', additionalData: { __typename?: 'UserListBlockAdditionalData', userList: { __typename?: 'UserList', name: string, items?: Maybe<Array<Maybe<{ __typename?: 'UserListItem', mediaID: number, watchStatus: string, rating?: Maybe<{ __typename?: 'UserListRating', displayRating: string }> }>>> } } };
+
+export type TextBlockFieldsFragment = { __typename?: 'TextBlock', textBlockInput: { __typename?: 'TextBlockSettings', text: string } };
+
+export type StatisticsBlockFieldsFragment = { __typename?: 'StatisticsBlock', additionalData: { __typename?: 'StatisticsBlockAdditionalData', entries: number } };
+
 export type UserListQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type UserListQuery = { __typename?: 'Query', me?: Maybe<{ __typename?: 'User', userList: Array<{ __typename?: 'UserListEntry', mediaID: number, rated: boolean, rating: number }> }> };
 
-
+export const UserListBlockFieldsFragmentDoc = gql`
+    fragment UserListBlockFields on UserListBlock {
+  additionalData {
+    userList {
+      name
+      items {
+        mediaID
+        watchStatus
+        rating {
+          displayRating
+        }
+      }
+    }
+  }
+}
+    `;
+export const TextBlockFieldsFragmentDoc = gql`
+    fragment TextBlockFields on TextBlock {
+  textBlockInput {
+    text
+  }
+}
+    `;
+export const StatisticsBlockFieldsFragmentDoc = gql`
+    fragment StatisticsBlockFields on StatisticsBlock {
+  additionalData {
+    entries
+  }
+}
+    `;
 export const _AddUserListItemDocument = gql`
     mutation _addUserListItem($input: AddUserListItemInput!) {
   addUserListItem(input: $input) {
@@ -904,6 +1037,53 @@ export function useMeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MeQuery
 export type MeQueryHookResult = ReturnType<typeof useMeQuery>;
 export type MeLazyQueryHookResult = ReturnType<typeof useMeLazyQuery>;
 export type MeQueryResult = Apollo.QueryResult<MeQuery, MeQueryVariables>;
+export const ProfileDocument = gql`
+    query Profile {
+  me {
+    username
+    userLists {
+      id
+      name
+    }
+    profilePageBlocks {
+      width
+      type
+      ...UserListBlockFields
+      ...TextBlockFields
+      ...StatisticsBlockFields
+    }
+  }
+}
+    ${UserListBlockFieldsFragmentDoc}
+${TextBlockFieldsFragmentDoc}
+${StatisticsBlockFieldsFragmentDoc}`;
+
+/**
+ * __useProfileQuery__
+ *
+ * To run a query within a React component, call `useProfileQuery` and pass it any options that fit your needs.
+ * When your component renders, `useProfileQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useProfileQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useProfileQuery(baseOptions?: Apollo.QueryHookOptions<ProfileQuery, ProfileQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProfileQuery, ProfileQueryVariables>(ProfileDocument, options);
+      }
+export function useProfileLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProfileQuery, ProfileQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProfileQuery, ProfileQueryVariables>(ProfileDocument, options);
+        }
+export type ProfileQueryHookResult = ReturnType<typeof useProfileQuery>;
+export type ProfileLazyQueryHookResult = ReturnType<typeof useProfileLazyQuery>;
+export type ProfileQueryResult = Apollo.QueryResult<ProfileQuery, ProfileQueryVariables>;
 export const UserListDocument = gql`
     query UserList {
   me {

--- a/client/src/graphql/queries/profile.graphql
+++ b/client/src/graphql/queries/profile.graphql
@@ -1,0 +1,46 @@
+query Profile {
+  me {
+    username
+
+    userLists {
+      id
+      name
+    }
+
+    profilePageBlocks {
+      width
+      type
+
+      ...UserListBlockFields
+      ...TextBlockFields
+      ...StatisticsBlockFields 
+    }
+  }
+}
+
+fragment UserListBlockFields on UserListBlock {
+  additionalData {
+    userList {
+      name
+      items {
+        mediaID
+        watchStatus
+        rating {
+          displayRating
+        }
+      }
+    }
+  }
+}
+
+fragment TextBlockFields on TextBlock {
+  textBlockInput {
+    text
+  }
+}
+
+fragment StatisticsBlockFields on StatisticsBlock {
+  additionalData {
+    entries
+  }
+}

--- a/client/src/pages/list/[listId].tsx
+++ b/client/src/pages/list/[listId].tsx
@@ -35,7 +35,9 @@ const ListPage: React.FC<{}> = () => {
 
   return (
     <VStack py={{ base: 10 }} width="full" maxWidth="6xl">
-      <UserList userlist={data.userList} isOwn={meData && meData.me && meData.me.id == data.userList.ownerId} />
+      <UserList userlist={data.userList}
+        isOwn={meData && meData.me && meData.me.id == data.userList.ownerId} 
+        fullSize={true} />
     </VStack>
   );
 };

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Spinner, VStack } from "@chakra-ui/react";
+import { Avatar, Box, Button, ButtonGroup, Center, Container, Grid, GridItem, Heading, HStack, Spinner, VStack, Text, Table, Tbody, Th, Thead, Tr, Td, Stat, StatArrow, StatGroup, StatHelpText, StatLabel, StatNumber } from "@chakra-ui/react";
 import * as React from 'react';
 import { useRouter } from "next/router";
 import ProfileCard from "../components/profiles/ProfileCard";
@@ -6,13 +6,14 @@ import { MalLinkOauthDocument, MalLinkOauthQuery, useMeQuery } from '../generate
 import useImperativeQuery from "../utils/useImperativeQuery";
 import { ApolloQueryResult } from "@apollo/client";
 import Link from "next/link";
+import UserListItem from "../components/list/_UserListItem";
 
 const Profile: React.FC<{}> = () => {
   const { data, loading } = useMeQuery();
   const malOauth = useImperativeQuery(MalLinkOauthDocument);
   const router = useRouter();
 
-  if (loading) { 
+  if (loading) {
     return (
       <Center
         flexGrow={1}
@@ -29,13 +30,25 @@ const Profile: React.FC<{}> = () => {
   }
 
   return (
-    <Center
-      py={{ base: 20, md: 36 }}
-      maxW={{ base: "sm", md: "xl" }}
-      width="full"
+    <VStack
+      py={{ base: 10, md: 10 }}
+      spacing="3rem"
+      width="100%"
+      maxWidth={{ base: "sm", md: "6xl" }}
     >
-      <VStack width="full">
-        <ProfileCard user={data.me} />
+      <HStack
+        spacing="3rem"
+        width="100%"
+      >
+        <Avatar
+          size={"lg"}
+          name={data.me.username}
+        />
+        <Heading>{data.me.username}</Heading>
+      </HStack>
+      <ButtonGroup
+        width="100%"
+      >
         <Button onClick={async () => {
           const { data }: ApolloQueryResult<MalLinkOauthQuery> = await malOauth();
           window.location.href = data.malLinkOauth;
@@ -43,13 +56,67 @@ const Profile: React.FC<{}> = () => {
           Link MAL
         </Button>
         <Link href="/createratingsystem">
-        <Button colorScheme="blue">Create Rating System</Button>
+          <Button colorScheme="blue">Create Rating System</Button>
         </Link>
         <Link href="/createlist">
-        <Button colorScheme="blue">Create a List</Button>
+          <Button colorScheme="blue">Create a List</Button>
         </Link>
-      </VStack>
-    </Center>
+      </ButtonGroup>
+      <Grid
+        width="100%"
+        templateRows='repeat(2, auto)'
+        gap={4}
+      >
+        <Box w='100%'>
+          <Text>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla bibendum ante ac ligula tincidunt, mattis dignissim nisl convallis. Vestibulum pulvinar molestie quam in lacinia. Aenean lacinia tristique velit. Duis non arcu orci. In feugiat erat sit amet maximus laoreet. Suspendisse aliquam elementum purus, ut consequat risus blandit et. In quis rhoncus augue, a hendrerit arcu.
+          </Text>
+        </Box>
+        <Box w='100%'>
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>Image</Th>
+                <Th>Anime title</Th>
+                <Th>Watch Status</Th>
+                <Th>Rating</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {
+                [1, 2, 3].map(i => <Tr>
+                  <Td>Test</Td>
+                  <Td>Test</Td>
+                  <Td>Test</Td>
+                  <Td>Test</Td>
+                </Tr>)
+              }
+            </Tbody>
+          </Table>
+        </Box>
+        <Box w="100%">
+          <StatGroup>
+            <Stat>
+              <StatLabel>Sent</StatLabel>
+              <StatNumber>345,670</StatNumber>
+              <StatHelpText>
+                <StatArrow type='increase' />
+                23.36%
+              </StatHelpText>
+            </Stat>
+
+            <Stat>
+              <StatLabel>Clicked</StatLabel>
+              <StatNumber>45</StatNumber>
+              <StatHelpText>
+                <StatArrow type='decrease' />
+                9.05%
+              </StatHelpText>
+            </Stat>
+          </StatGroup>
+        </Box>
+      </Grid>
+    </VStack>
   );
 };
 

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -67,11 +67,7 @@ const Profile: React.FC<{}> = () => {
       
       <ProfilePageBlockGrid blocks={data.me.profilePageBlocks} />
 
-        <Box w='100%'>
-          <Text>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla bibendum ante ac ligula tincidunt, mattis dignissim nisl convallis. Vestibulum pulvinar molestie quam in lacinia. Aenean lacinia tristique velit. Duis non arcu orci. In feugiat erat sit amet maximus laoreet. Suspendisse aliquam elementum purus, ut consequat risus blandit et. In quis rhoncus augue, a hendrerit arcu.
-          </Text>
-        </Box>
+      <Grid>
         <Box w='100%'>
           <Table>
             <Thead>
@@ -94,6 +90,7 @@ const Profile: React.FC<{}> = () => {
             </Tbody>
           </Table>
         </Box>
+      </Grid>
        
     </VStack>
   );

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -67,31 +67,6 @@ const Profile: React.FC<{}> = () => {
       
       <ProfilePageBlockGrid blocks={data.me.profilePageBlocks} />
 
-      <Grid>
-        <Box w='100%'>
-          <Table>
-            <Thead>
-              <Tr>
-                <Th>Image</Th>
-                <Th>Anime title</Th>
-                <Th>Watch Status</Th>
-                <Th>Rating</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {
-                [1, 2, 3].map(i => <Tr>
-                  <Td>Test</Td>
-                  <Td>Test</Td>
-                  <Td>Test</Td>
-                  <Td>Test</Td>
-                </Tr>)
-              }
-            </Tbody>
-          </Table>
-        </Box>
-      </Grid>
-       
     </VStack>
   );
 };

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -2,14 +2,15 @@ import { Avatar, Box, Button, ButtonGroup, Center, Container, Grid, GridItem, He
 import * as React from 'react';
 import { useRouter } from "next/router";
 import ProfileCard from "../components/profiles/ProfileCard";
-import { MalLinkOauthDocument, MalLinkOauthQuery, useMeQuery } from '../generated/graphql';
+import { MalLinkOauthDocument, MalLinkOauthQuery, useProfileQuery } from '../generated/graphql';
 import useImperativeQuery from "../utils/useImperativeQuery";
 import { ApolloQueryResult } from "@apollo/client";
 import Link from "next/link";
 import UserListItem from "../components/list/_UserListItem";
+import ProfilePageBlockGrid from "../components/profiles/ProfilePageBlockGrid";
 
 const Profile: React.FC<{}> = () => {
-  const { data, loading } = useMeQuery();
+  const { data, loading } = useProfileQuery();
   const malOauth = useImperativeQuery(MalLinkOauthDocument);
   const router = useRouter();
 
@@ -62,11 +63,10 @@ const Profile: React.FC<{}> = () => {
           <Button colorScheme="blue">Create a List</Button>
         </Link>
       </ButtonGroup>
-      <Grid
-        width="100%"
-        templateRows='repeat(2, auto)'
-        gap={4}
-      >
+
+      
+      <ProfilePageBlockGrid blocks={data.me.profilePageBlocks} />
+
         <Box w='100%'>
           <Text>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla bibendum ante ac ligula tincidunt, mattis dignissim nisl convallis. Vestibulum pulvinar molestie quam in lacinia. Aenean lacinia tristique velit. Duis non arcu orci. In feugiat erat sit amet maximus laoreet. Suspendisse aliquam elementum purus, ut consequat risus blandit et. In quis rhoncus augue, a hendrerit arcu.
@@ -115,7 +115,6 @@ const Profile: React.FC<{}> = () => {
             </Stat>
           </StatGroup>
         </Box>
-      </Grid>
     </VStack>
   );
 };

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -94,27 +94,7 @@ const Profile: React.FC<{}> = () => {
             </Tbody>
           </Table>
         </Box>
-        <Box w="100%">
-          <StatGroup>
-            <Stat>
-              <StatLabel>Sent</StatLabel>
-              <StatNumber>345,670</StatNumber>
-              <StatHelpText>
-                <StatArrow type='increase' />
-                23.36%
-              </StatHelpText>
-            </Stat>
-
-            <Stat>
-              <StatLabel>Clicked</StatLabel>
-              <StatNumber>45</StatNumber>
-              <StatHelpText>
-                <StatArrow type='decrease' />
-                9.05%
-              </StatHelpText>
-            </Stat>
-          </StatGroup>
-        </Box>
+       
     </VStack>
   );
 };


### PR DESCRIPTION
In this PR:
* Add a `fullSize` prop to the UserList component, allowing us to control whether the list displays as a full-sized list (as on the standalone list page) or a miniaturized version (as on the profile page).
  * Add a `showImage` prop to the UserListItem subcomponent, controlling whether the list item displays the media's image. The UserList component sets this to whatever the `fullSize` prop is.
* Create components for each of the four block types that take in the data and display it.
* Create a `ProfilePageBlock` component that takes in a generic `Block` type and returns the appropriate block component, selected from the four components above, wrapped in a rounded and bordered box
* Create a `ProfilePageBlockGrid` component that takes the 2D list of blocks and uses the ProfilePageBlock component to display all of them.
* Query for the user's profile blocks on the profile page and use the fetched data to show the ProfilePageBlockGrid.

Closes #110 . Closes #111 .

Profile page showing a text block, spacer, statistics, then user list block:
![image](https://user-images.githubusercontent.com/3297639/144572672-e8497cdd-1f46-4e11-9d83-4d8cfee3b88b.png)
